### PR TITLE
Add logic for post upgrade

### DIFF
--- a/config/crds/cdap_v1alpha1_cdapmaster.yaml
+++ b/config/crds/cdap_v1alpha1_cdapmaster.yaml
@@ -408,10 +408,11 @@ spec:
                 by the API Server.
               format: int64
               type: integer
-            upgradeJobVersion:
-              description: UpgradeJobVersion is a unique identifier of the upgrade
-                job.
-              type: string
+            upgradeStartTimeMillis:
+              description: UpgradeStartTimeMillis is the start time in millis of the
+                upgrade process
+              format: int64
+              type: integer
             userInterfaceImageToUse:
               description: UserInterfaceImageToUse is the Docker image of CDAP UI
                 the operator uses to deploy.

--- a/pkg/apis/cdap/v1alpha1/cdapmaster_types.go
+++ b/pkg/apis/cdap/v1alpha1/cdapmaster_types.go
@@ -143,8 +143,8 @@ type CDAPMasterStatus struct {
 	ImageToUse string `json:"imageToUse,omitempty"`
 	// UserInterfaceImageToUse is the Docker image of CDAP UI the operator uses to deploy.
 	UserInterfaceImageToUse string `json:"userInterfaceImageToUse,omitempty"`
-	// UpgradeJobVersion is a unique identifier of the upgrade job.
-	UpgradeJobVersion string `json:"upgradeJobVersion,omitempty"`
+	// UpgradeStartTimeMillis is the start time in millis of the upgrade process
+	UpgradeStartTimeMillis int64 `json:"upgradeStartTimeMillis,omitempty"`
 }
 
 // +genclient

--- a/pkg/controller/cdapmaster/cdapmaster_controller.go
+++ b/pkg/controller/cdapmaster/cdapmaster_controller.go
@@ -601,7 +601,7 @@ func (b *Base) Objects(rsrc interface{}, rsrclabels map[string]string, observed,
 	// Post upgrade case, in which the image has updated successfully and all pods are back up
 	if master.Status.UpgradeStartTimeMillis != 0 && master.Status.IsReady() {
 		var postUpgradeJob *batchv1.Job
-		item := k8s.GetItem(observed, &batchv1.Job{}, getPostUpgradeJobName(master), "default")
+		item := k8s.GetItem(observed, &batchv1.Job{}, getPostUpgradeJobName(master), master.Namespace)
 		if item != nil {
 			postUpgradeJob = item.(*batchv1.Job)
 		}
@@ -640,7 +640,7 @@ func (b *Base) Objects(rsrc interface{}, rsrclabels map[string]string, observed,
 	var upgradeResources []reconciler.Object
 	var upgradeJob *batchv1.Job
 	if master.Status.UpgradeStartTimeMillis != 0 {
-		item := k8s.GetItem(observed, &batchv1.Job{}, getUpgradeJobName(master), "default")
+		item := k8s.GetItem(observed, &batchv1.Job{}, getUpgradeJobName(master), master.Namespace)
 		if item != nil {
 			upgradeJob = item.(*batchv1.Job)
 		}

--- a/pkg/controller/cdapmaster/cdapmaster_controller.go
+++ b/pkg/controller/cdapmaster/cdapmaster_controller.go
@@ -274,6 +274,7 @@ type upgradeJobSpec struct {
 	ReferentUID        types.UID `json:"referentUID,omitempty"`
 	SecuritySecret     string `json:"securitySecret,omitempty"`
 	StartTimeMillis    int64 `json:"startTimeMillis,omitempty"`
+	Namespace          string `json:"namespace,omitempty"`
 }
 
 // Returns the resource name for the given resource
@@ -472,21 +473,17 @@ func getPostUpgradeJobResources(master *alpha1.CDAPMaster, rsrclabels map[string
 	return getUpgradeJobResources(master, rsrclabels, master.Status.UpgradeStartTimeMillis, getPostUpgradeJobName(master))
 }
 
-func compareVersion(a, b string) int {
-	av:= strings.Split(a, ":")
-	bv := strings.Split(b, ":")
-
-	var versiona, versionb string
+func getVersion(a string) string {
+	av := strings.Split(a, ":")
 	if len(av) == 1 {
-		versiona = latestVersion
-	} else {
-		versiona = av[1]
+		 return latestVersion
 	}
-	if len(bv) == 1 {
-		versionb = latestVersion
-	} else {
-		versionb = bv[1]
-	}
+	return av[1]
+}
+
+func compareVersion(a, b string) int {
+	versiona := getVersion(a)
+	versionb := getVersion(b)
 
 	if latestVersion == versiona && latestVersion == versionb {
 		return 0
@@ -533,6 +530,7 @@ func getUpgradeJobResources(master *alpha1.CDAPMaster, rsrclabels map[string]str
 		ReferentApiVersion: master.APIVersion,
 		ReferentUID:        master.UID,
 		SecuritySecret:     master.Spec.SecuritySecret,
+		Namespace:          master.Namespace,
 	}
 	if startTimeMillis != 0 {
 		spec.StartTimeMillis = startTimeMillis

--- a/pkg/controller/cdapmaster/cdapmaster_controller.go
+++ b/pkg/controller/cdapmaster/cdapmaster_controller.go
@@ -19,7 +19,6 @@ package cdapmaster
 import (
 	alpha1 "cdap.io/cdap-operator/pkg/apis/cdap/v1alpha1"
 	"fmt"
-	"github.com/google/uuid"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -31,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-reconciler/pkg/reconciler/manager/k8s"
 	"sigs.k8s.io/controller-reconciler/pkg/status"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -48,12 +48,18 @@ const (
 	serviceTemplate      = "cdap-service.yaml"
 	upgradeJobTemplate   = "upgrade-job.yaml"
 
-	upgradeFailed            = "upgrade-failed"
-	upgradeStartMessage      = "Upgrade started, received updated CR."
-	upgradeFailedInitMessage = "Failed to create job, upgrade failed."
-	upgradeJobFailedMessage  = "Upgrade job failed."
-	upgradeResetMessage      = "Upgrade spec reset."
-	upgradeFailureLimit      = 4
+	upgradeFailed             = "upgrade-failed"
+	postUpgradeFailed         = "post-upgrade-failed"
+	postUpgradeFinished       = "post-upgrade-finished"
+	upgradeStartMessage       = "Upgrade started, received updated CR."
+	upgradeFailedInitMessage  = "Failed to create job, upgrade failed."
+	upgradeJobFailedMessage   = "Upgrade job failed."
+	upgradeJobFinishedMessage = "Upgrade job finished."
+	upgradeJobSkippedMessage  = "Upgrade job skipped."
+	upgradeResetMessage       = "Upgrade spec reset."
+	upgradeFailureLimit       = 4
+
+	latestVersion = "latest"
 )
 
 // Add the manager to the controller.
@@ -267,6 +273,7 @@ type upgradeJobSpec struct {
 	ReferentApiVersion string    `json:"referentApiVersion,omitempty"`
 	ReferentUID        types.UID `json:"referentUID,omitempty"`
 	SecuritySecret     string `json:"securitySecret,omitempty"`
+	StartTimeMillis    int64 `json:"startTimeMillis,omitempty"`
 }
 
 // Returns the resource name for the given resource
@@ -274,22 +281,14 @@ func getResourceName(r *alpha1.CDAPMaster, resource string) string {
 	return fmt.Sprintf("cdap-%s-%s", r.Name, strings.ToLower(resource))
 }
 
-// Gets the set of resources for the pre-upgrade job.
-func getPreUpgradeResources(s *upgradeJobSpec, rsrclabels map[string]string, r *alpha1.CDAPMaster) ([]reconciler.Object, error) {
-	ngdata := &upgradeValue{Job: s}
-	ngdata.Labels = rsrclabels
-	ngdata.CConfName = getResourceName(r, "cconf")
-	ngdata.HConfName = getResourceName(r, "hconf")
-	item, err := k8s.ObjectFromFile(templateDir + upgradeJobTemplate, ngdata, &batchv1.JobList{})
-	if err != nil {
-		return nil, err
-	}
-	return append([]reconciler.Object{}, *item), nil
+// Gets the name of the upgrade job based on resource version. Name can be no more than 63 chars.
+func getUpgradeJobName(r *alpha1.CDAPMaster) string {
+	return fmt.Sprintf("cdap-%s-uj-%d", r.Name, r.Status.UpgradeStartTimeMillis)
 }
 
-// Gets the name of the upgrade job based on resource version.
-func getUpgradeJobName(r *alpha1.CDAPMaster) string {
-	return fmt.Sprintf("cdap-%s-upgrade-job-%s", r.Name, r.Status.UpgradeJobVersion)
+// Gets the name of the post upgrade job based on resource version. Name can be no more than 63 chars.
+func getPostUpgradeJobName(r *alpha1.CDAPMaster) string {
+	return fmt.Sprintf("cdap-%s-puj-%d", r.Name, r.Status.UpgradeStartTimeMillis)
 }
 
 // Gets the set of resources for the given service represented by the CDAPServiceSpec.
@@ -437,6 +436,12 @@ func logbackFromFile(t string, data interface{}) (string, error) {
 	return output.String(), nil
 }
 
+func resetUpgradeConditions(master *alpha1.CDAPMaster, message string) {
+	master.Status.ClearCondition(upgradeFailed, message, message)
+	master.Status.ClearCondition(postUpgradeFailed, message, message)
+	master.Status.ClearCondition(postUpgradeFinished, message, message)
+}
+
 // Adds a component list object in state in progress. This will cause UpdateStatus to update the
 // ready type to state "false".
 func addUpgradeComponentNotReady(master *alpha1.CDAPMaster) {
@@ -447,8 +452,7 @@ func addUpgradeComponentNotReady(master *alpha1.CDAPMaster) {
 }
 
 func prepareNewPreUpgradeJobResources(master *alpha1.CDAPMaster, rsrclabels map[string]string) ([]reconciler.Object, error) {
-	master.Status.UpgradeJobVersion = uuid.New().String()
-	master.Status.Meta.ClearCondition(upgradeFailed, upgradeStartMessage, upgradeStartMessage)
+	resetUpgradeConditions(master, upgradeStartMessage)
 
 	upgradeResources, err := getPreUpgradeJobResources(master, rsrclabels)
 	if err != nil {
@@ -458,25 +462,90 @@ func prepareNewPreUpgradeJobResources(master *alpha1.CDAPMaster, rsrclabels map[
 	return upgradeResources, nil
 }
 
-// Gets the job resources and sets status to not ready, since any time when we wish to add the job
-// to expected, the status is not ready.
+// Gets pre upgrade job resources
 func getPreUpgradeJobResources(master *alpha1.CDAPMaster, rsrclabels map[string]string) ([]reconciler.Object, error) {
-	upgradeResources, err := getPreUpgradeResources(
-		&upgradeJobSpec{
-			Image:              master.Spec.Image,
-			JobName:            getUpgradeJobName(master),
-			HostName:           getResourceName(master, string(alpha1.ServiceRouter)),
-			BackoffLimit:       upgradeFailureLimit,
-			ReferentName:       master.Name,
-			ReferentKind:       master.Kind,
-			ReferentApiVersion: master.APIVersion,
-			ReferentUID:        master.UID,
-			SecuritySecret:     master.Spec.SecuritySecret,
-		}, rsrclabels, master)
+	return getUpgradeJobResources(master, rsrclabels, 0, getUpgradeJobName(master))
+}
+
+// Gets post upgrade job resources
+func getPostUpgradeJobResources(master *alpha1.CDAPMaster, rsrclabels map[string]string) ([]reconciler.Object, error) {
+	return getUpgradeJobResources(master, rsrclabels, master.Status.UpgradeStartTimeMillis, getPostUpgradeJobName(master))
+}
+
+func compareVersion(a, b string) int {
+	av:= strings.Split(a, ":")
+	bv := strings.Split(b, ":")
+
+	var versiona, versionb string
+	if len(av) == 1 {
+		versiona = latestVersion
+	} else {
+		versiona = av[1]
+	}
+	if len(bv) == 1 {
+		versionb = latestVersion
+	} else {
+		versionb = bv[1]
+	}
+
+	if latestVersion == versiona && latestVersion == versionb {
+		return 0
+	} else if latestVersion == versiona {
+		return -1
+	} else if latestVersion == versionb {
+		return 1
+	}
+
+	as := strings.Split(versiona, ".")
+	bs := strings.Split(versionb, ".")
+	loopMax := len(bs)
+	if len(as) > len(bs) {
+		loopMax = len(as)
+	}
+	for i := 0; i < loopMax; i++ {
+		var x, y string
+		if len(as) > i {
+			x = as[i]
+		}
+		if len(bs) > i {
+			y = bs[i]
+		}
+		xi,_ := strconv.Atoi(x)
+		yi,_ := strconv.Atoi(y)
+		if xi > yi {
+			return -1
+		} else if xi < yi {
+			return 1
+		}
+	}
+	return 0
+}
+
+// Gets upgrade job resources
+func getUpgradeJobResources(master *alpha1.CDAPMaster, rsrclabels map[string]string, startTimeMillis int64, name string) ([]reconciler.Object, error) {
+	var spec = &upgradeJobSpec{
+		Image:              master.Spec.Image,
+		JobName:            name,
+		HostName:           getResourceName(master, string(alpha1.ServiceRouter)),
+		BackoffLimit:       upgradeFailureLimit,
+		ReferentName:       master.Name,
+		ReferentKind:       master.Kind,
+		ReferentApiVersion: master.APIVersion,
+		ReferentUID:        master.UID,
+		SecuritySecret:     master.Spec.SecuritySecret,
+	}
+	if startTimeMillis != 0 {
+		spec.StartTimeMillis = startTimeMillis
+	}
+	ngdata := &upgradeValue{Job: spec}
+	ngdata.Labels = rsrclabels
+	ngdata.CConfName = getResourceName(master, "cconf")
+	ngdata.HConfName = getResourceName(master, "hconf")
+	item, err := k8s.ObjectFromFile(templateDir + upgradeJobTemplate, ngdata, &batchv1.JobList{})
 	if err != nil {
 		return nil, err
 	}
-	return upgradeResources, nil
+	return append([]reconciler.Object{}, *item), nil
 }
 
 // Updates the component status
@@ -515,7 +584,45 @@ func (b *Base) Objects(rsrc interface{}, rsrclabels map[string]string, observed,
 	if master.Status.Meta.IsConditionTrue(upgradeFailed) {
 		// User has reset the CR after failure. Remove upgrade failed status.
 		if master.Spec.Image == master.Status.ImageToUse {
-			master.Status.ClearCondition(upgradeFailed, upgradeResetMessage, upgradeResetMessage)
+			resetUpgradeConditions(master, upgradeResetMessage)
+		}
+		return resources, nil
+	}
+
+	// Downgrade case, we want to set the imageToUse to spec while not performing pre or post upgrade jobs
+	if compareVersion(master.Status.ImageToUse, master.Spec.Image) == -1 {
+		master.Status.ImageToUse = master.Spec.Image
+		master.Status.UserInterfaceImageToUse = master.Spec.UserInterfaceImage
+		master.Status.SetCondition(postUpgradeFinished, upgradeJobSkippedMessage, upgradeJobSkippedMessage)
+		return resources, nil
+	}
+
+	// Post upgrade case, in which the image has updated successfully and all pods are back up
+	if master.Status.UpgradeStartTimeMillis != 0 && master.Status.IsReady() {
+		var postUpgradeJob *batchv1.Job
+		item := k8s.GetItem(observed, &batchv1.Job{}, getPostUpgradeJobName(master), "default")
+		if item != nil {
+			postUpgradeJob = item.(*batchv1.Job)
+		}
+
+		postUpgradeResources, err := getPostUpgradeJobResources(master, rsrclabels)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, postUpgradeResources...)
+
+		if postUpgradeJob == nil {
+			return resources, nil
+		}
+
+		if postUpgradeJob.Status.Succeeded > 0 {
+			// Post upgrade job has succeeded.
+			master.Status.UpgradeStartTimeMillis = 0
+			master.Status.Meta.SetCondition(postUpgradeFinished, upgradeJobFinishedMessage, upgradeJobFinishedMessage)
+		} else if postUpgradeJob.Status.Failed >= upgradeFailureLimit {
+			// Post upgrade job has failed
+			master.Status.UpgradeStartTimeMillis = 0
+			master.Status.Meta.SetCondition(postUpgradeFailed, upgradeJobFailedMessage, upgradeJobFailedMessage)
 		}
 		return resources, nil
 	}
@@ -531,7 +638,7 @@ func (b *Base) Objects(rsrc interface{}, rsrclabels map[string]string, observed,
 
 	var upgradeResources []reconciler.Object
 	var upgradeJob *batchv1.Job
-	if master.Status.UpgradeJobVersion != "" {
+	if master.Status.UpgradeStartTimeMillis != 0 {
 		item := k8s.GetItem(observed, &batchv1.Job{}, getUpgradeJobName(master), "default")
 		if item != nil {
 			upgradeJob = item.(*batchv1.Job)
@@ -540,6 +647,8 @@ func (b *Base) Objects(rsrc interface{}, rsrclabels map[string]string, observed,
 
 	if upgradeJob == nil {
 		// Add a new job and set ready status to false
+		master.Status.UpgradeStartTimeMillis =
+				time.Now().UnixNano() / (int64(time.Millisecond)/int64(time.Nanosecond))
 		var err error
 		upgradeResources, err = prepareNewPreUpgradeJobResources(master, rsrclabels)
 		if err != nil {
@@ -553,11 +662,10 @@ func (b *Base) Objects(rsrc interface{}, rsrclabels map[string]string, observed,
 		// Pre upgrade job has succeeded.
 		master.Status.ImageToUse = master.Spec.Image
 		master.Status.UserInterfaceImageToUse = master.Spec.UserInterfaceImage
-		master.Status.UpgradeJobVersion = ""
 		addUpgradeComponentNotReady(master)
 	} else if upgradeJob.Status.Failed >= upgradeFailureLimit {
 		// Pre upgrade job has failed
-		master.Status.UpgradeJobVersion = ""
+		master.Status.UpgradeStartTimeMillis = 0
 		master.Status.Meta.SetCondition(upgradeFailed, upgradeJobFailedMessage, upgradeJobFailedMessage)
 	} else {
 		// Pre upgrade job has already been initialized, but has not finished

--- a/templates/upgrade-job.yaml
+++ b/templates/upgrade-job.yaml
@@ -15,7 +15,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{.Job.JobName}}
-  namespace: default
+  namespace: {{.Job.Namespace}}
 {{if .Labels}}
   labels:
     {{range $k,$v := .Labels}}

--- a/templates/upgrade-job.yaml
+++ b/templates/upgrade-job.yaml
@@ -32,16 +32,21 @@ spec:
   template:
     metadata:
     {{if .Labels}}
-    labels:
+      labels:
         {{range $k,$v := .Labels}}
           {{$k}}: '{{$v}}'
           {{end}}
     {{end}}
     spec:
       containers:
+        {{if .Job.StartTimeMillis}}
+        - name: post-upgrade
+          args: ["io.cdap.cdap.master.upgrade.PostUpgradeJobMain", "{{.Job.HostName}}", "11015", "{{.Job.StartTimeMillis}}"]
+        {{else}}
         - name: pre-upgrade
-          image: {{.Job.Image}}
           args: ["io.cdap.cdap.master.upgrade.UpgradeJobMain", "{{.Job.HostName}}", "11015"]
+        {{end}}
+          image: {{.Job.Image}}
           volumeMounts:
             - name: cdap-conf
               mountPath: /etc/cdap/conf


### PR DESCRIPTION
- Add logic to start a post upgrade job after the operator is back up in a ready state
- Remove UpgradeJobVersion, since the UUID is too long to include in the job name, and startTimeMillis effectively fills the same purpose.
- Add logic to handle downgrade case - skip pre/post upgrade jobs