### PR TITLE
Fix Dockerfile for CDAP Operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
 # Build the manager binary
 FROM golang:1.13 as builder
 
-# Copy in the go src
+# Copy everything in the go src
 WORKDIR /go/src/cdap.io/cdap-operator
-COPY api/ api/
-COPY vendor/ vendor/
-COPY main.go main.go
-COPY controllers/ controllers/
 COPY ./ ./
 
 # Build
@@ -18,6 +14,5 @@ FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /go/src/cdap.io/cdap-operator/manager .
 COPY templates/ templates/
-COPY config/crd/ crds/
 COPY config/ config/
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,8 @@ COPY ./ ./
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager ./main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+# Copy the controller-manager into a thin image
+FROM ubuntu:latest
 WORKDIR /
 COPY --from=builder /go/src/cdap.io/cdap-operator/manager .
 COPY templates/ templates/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,23 @@
 # Build the manager binary
 FROM golang:1.13 as builder
 
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy the go source
-COPY main.go main.go
+# Copy in the go src
+WORKDIR /go/src/cdap.io/cdap-operator
 COPY api/ api/
+COPY vendor/ vendor/
+COPY main.go main.go
 COPY controllers/ controllers/
+COPY ./ ./
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager ./main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
-
+COPY --from=builder /go/src/cdap.io/cdap-operator/manager .
+COPY templates/ templates/
+COPY config/crd/ crds/
+COPY config/ config/
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Current version of Dockerfile is not able to run. Fixed Dockerfile to build image with all dependencies and tested it manually on a running CDAP instance. Also tested end to end with spinning up CDAP using Operator and clients.