### PR TITLE
Quote many user provided values in Yaml templates

### DIFF
--- a/templates/cdap-deployment.yaml
+++ b/templates/cdap-deployment.yaml
@@ -19,21 +19,21 @@ metadata:
   {{if .Base.Labels}}
   labels:
     {{range $k,$v := .Base.Labels}}
-    {{$k}}: {{$v}}
+    {{$k}}: "{{$v}}"
     {{end}}
   {{end}}
 spec:
   selector:
     matchLabels:
       {{range $k,$v := .Base.Labels}}
-      {{$k}}: {{$v}}
+      {{$k}}: "{{$v}}"
       {{end}}
   replicas: {{.Base.Replicas}}
   template:
     metadata:
       labels:
         {{range $k,$v := .Base.Labels }}
-        {{$k}}: {{$v}}
+        {{$k}}: "{{$v}}"
         {{end}}
     spec:
       {{if .Base.ServiceAccountName}}
@@ -41,7 +41,7 @@ spec:
       {{end}}
       nodeSelector:
         {{range $k,$v := .Base.NodeSelector}}
-        {{$k}}: {{$v}}
+        {{$k}}: "{{$v}}"
         {{end}}
       {{if .Base.RuntimeClassName}}
       runtimeClassName: {{.Base.RuntimeClassName}}
@@ -68,8 +68,8 @@ spec:
           {{end}}
           env:
           {{range $e := $c.Env }}
-          - name: {{$e.Name}}
-            value: {{$e.Value}}
+          - name: "{{$e.Name}}"
+            value: "{{$e.Value}}"
           {{end}}
           resources:
             {{if $c.ResourceRequests}}

--- a/templates/cdap-service.yaml
+++ b/templates/cdap-service.yaml
@@ -19,12 +19,12 @@ metadata:
   labels:
     cdap.service: {{.Name}}
     {{range $k,$v := .Labels}}
-    {{$k}}: {{$v}}
+    {{$k}}: "{{$v}}"
     {{end}}
 {{if .Annotations}}
   annotations:
     {{range $k,$v := .Annotations}}
-    {{$k}}: '{{$v}}'
+    {{$k}}: "{{$v}}"
     {{end}}
 {{end}}
 spec:
@@ -35,7 +35,7 @@ spec:
 {{end}}
   selector:
     {{range $k,$v := .Selectors}}
-    {{$k}}: '{{$v}}'
+    {{$k}}: "{{$v}}"
     {{end}}
   ports:
 

--- a/templates/cdap-sts.yaml
+++ b/templates/cdap-sts.yaml
@@ -19,14 +19,14 @@ metadata:
   {{if .Base.Labels}}
   labels:
     {{range $k,$v := .Base.Labels}}
-    {{$k}}: {{$v}}
+    {{$k}}: "{{$v}}"
     {{end}}
   {{end}}
 spec:
   selector:
     matchLabels:
       {{range $k,$v := .Base.Labels}}
-      {{$k}}: {{$v}}
+      {{$k}}: "{{$v}}"
       {{end}}
   serviceName: {{.Base.Name}}
   replicas: {{.Base.Replicas}}
@@ -34,7 +34,7 @@ spec:
     metadata:
       labels:
         {{range $k,$v := .Base.Labels }}
-        {{$k}}: {{$v}}
+        {{$k}}: "{{$v}}"
         {{end}}
     spec:
       {{if .Base.ServiceAccountName}}
@@ -42,7 +42,7 @@ spec:
       {{end}}
       nodeSelector:
         {{range $k,$v := .Base.NodeSelector}}
-        {{$k}}: {{$v}}
+        {{$k}}: "{{$v}}"
         {{end}}
       {{if .Base.RuntimeClassName}}
       runtimeClassName: {{.BaseRuntimeClassName}}

--- a/templates/upgrade-job.yaml
+++ b/templates/upgrade-job.yaml
@@ -19,7 +19,7 @@ metadata:
   {{if .Labels}}
   labels:
     {{range $k,$v := .Labels}}
-    {{$k}}: {{$v}}
+    {{$k}}: "{{$v}}"
     {{end}}
   {{end}}
   ownerReferences:
@@ -34,7 +34,7 @@ spec:
       {{if .Labels}}
       labels:
         {{range $k,$v := .Labels}}
-          {{$k}}: {{$v}}
+          {{$k}}: "{{$v}}"
           {{end}}
       {{end}}
     spec:


### PR DESCRIPTION
This fixes issue #27, where K8S would implicitly assume a value was a number/boolean/etc. instead of a string in the given Yaml template, due to the value not being quoted.