### PR TITLE
Change Appfabric and Metadata from deployment to statefulset.

### DIFF
--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -46,10 +46,10 @@ func (d *DeploymentPlan) Init() {
 			"messaging": {serviceMessaging},
 			"metrics":   {serviceMetrics},
 			"preview":   {servicePreview},
+			"appfabric": {serviceAppFabric},
+			"metadata":  {serviceMetadata},
 		},
 		deployment: map[ServiceGroupName]ServiceGroup{
-			"appfabric":     {serviceAppFabric},
-			"metadata":      {serviceMetadata},
 			"router":        {serviceRouter},
 			"userinterface": {serviceUserInterface},
 		},

--- a/controllers/testdata/appfabric.json
+++ b/controllers/testdata/appfabric.json
@@ -1,6 +1,6 @@
 {
   "apiVersion": "apps/v1",
-  "kind": "Deployment",
+  "kind": "StatefulSet",
   "metadata": {
     "annotations": {
       "deployment.kubernetes.io/revision": "8"
@@ -52,6 +52,7 @@
       },
       "type": "RollingUpdate"
     },
+    "serviceName": "cdap-test-appfabric",
     "template": {
       "metadata": {
         "creationTimestamp": null,
@@ -110,9 +111,55 @@
                 "readOnly": true
               },
               {
+                "mountPath": "/data",
+                "name": "cdap-test-appfabric-data",
+                "readOnly": true
+              },
+              {
                 "mountPath": "/etc/cdap/security",
                 "name": "cdap-security",
                 "readOnly": true
+              }
+            ]
+          }
+        ],
+        "initContainers": [
+          {
+            "name": "storageinit",
+            "image": "gcr.io/cloud-data-fusion-images/cloud-data-fusion:6.1.0.5",
+            "args": [
+              "io.cdap.cdap.master.environment.k8s.StorageMain"
+            ],
+            "resources": {},
+            "volumeMounts": [
+              {
+                "name": "podinfo",
+                "readOnly": true,
+                "mountPath": "/etc/podinfo"
+              },
+              {
+                "name": "cdap-conf",
+                "readOnly": true,
+                "mountPath": "/etc/cdap/conf"
+              },
+              {
+                "name": "hadoop-conf",
+                "readOnly": true,
+                "mountPath": "/etc/hadoop/conf"
+              },
+              {
+                "name": "cdap-sysappconf",
+                "readOnly": true,
+                "mountPath": "/opt/cdap/master/system-app-config"
+              },
+              {
+                "mountPath": "/data",
+                "name": "cdap-test-appfabric-data"
+              },
+              {
+                "name": "cdap-security",
+                "readOnly": true,
+                "mountPath": "/etc/cdap/security"
               }
             ]
           }
@@ -177,7 +224,27 @@
           }
         ]
       }
-    }
+    },
+    "updateStrategy": {},
+    "volumeClaimTemplates": [
+      {
+        "metadata": {
+          "name": "cdap-test-appfabric-data",
+          "creationTimestamp": null
+        },
+        "spec": {
+          "accessModes": [
+            "ReadWriteOnce"
+          ],
+          "resources": {
+            "requests": {
+              "storage": "200Gi"
+            }
+          }
+        },
+        "status": {}
+      }
+    ]
   },
   "status": {
     "availableReplicas": 1,

--- a/controllers/testdata/metadata.json
+++ b/controllers/testdata/metadata.json
@@ -1,6 +1,6 @@
 {
   "apiVersion": "apps/v1",
-  "kind": "Deployment",
+  "kind": "StatefulSet",
   "metadata": {
     "annotations": {
       "deployment.kubernetes.io/revision": "8"
@@ -45,6 +45,7 @@
         "using": "controllers.ServiceHandler"
       }
     },
+    "serviceName": "cdap-test-metadata",
     "strategy": {
       "rollingUpdate": {
         "maxSurge": "25%",
@@ -110,9 +111,55 @@
                 "readOnly": true
               },
               {
+                "mountPath": "/data",
+                "name": "cdap-test-metadata-data",
+                "readOnly": true
+              },
+              {
                 "mountPath": "/etc/cdap/security",
                 "name": "cdap-security",
                 "readOnly": true
+              }
+            ]
+          }
+        ],
+        "initContainers": [
+          {
+            "name": "storageinit",
+            "image": "gcr.io/cloud-data-fusion-images/cloud-data-fusion:6.1.0.5",
+            "args": [
+              "io.cdap.cdap.master.environment.k8s.StorageMain"
+            ],
+            "resources": {},
+            "volumeMounts": [
+              {
+                "name": "podinfo",
+                "readOnly": true,
+                "mountPath": "/etc/podinfo"
+              },
+              {
+                "name": "cdap-conf",
+                "readOnly": true,
+                "mountPath": "/etc/cdap/conf"
+              },
+              {
+                "name": "hadoop-conf",
+                "readOnly": true,
+                "mountPath": "/etc/hadoop/conf"
+              },
+              {
+                "name": "cdap-sysappconf",
+                "readOnly": true,
+                "mountPath": "/opt/cdap/master/system-app-config"
+              },
+              {
+                "mountPath": "/data",
+                "name": "cdap-test-metadata-data"
+              },
+              {
+                "name": "cdap-security",
+                "readOnly": true,
+                "mountPath": "/etc/cdap/security"
               }
             ]
           }
@@ -177,7 +224,27 @@
           }
         ]
       }
-    }
+    },
+    "updateStrategy": {},
+    "volumeClaimTemplates": [
+      {
+        "metadata": {
+          "name": "cdap-test-metadata-data",
+          "creationTimestamp": null
+        },
+        "spec": {
+          "accessModes": [
+            "ReadWriteOnce"
+          ],
+          "resources": {
+            "requests": {
+              "storage": "200Gi"
+            }
+          }
+        },
+        "status": {}
+      }
+    ]
   },
   "status": {
     "availableReplicas": 1,
@@ -201,7 +268,7 @@
     ],
     "observedGeneration": 537,
     "readyReplicas": 1,
-    "replicas": 1,
+    "replicas": 0,
     "updatedReplicas": 1
   }
 }


### PR DESCRIPTION
Change Appfabric and Metadata to stateful. 

This is to support cases like: Run CDAP in distributed mode with per service local levelDB.