### PR TITLE
Fixing a bug in upgrade. Should run post-upgrade job but mistakenly run pre-upgrade

### DIFF
--- a/controllers/testdata/post_upgrade_job.json
+++ b/controllers/testdata/post_upgrade_job.json
@@ -59,13 +59,14 @@
         "containers": [
           {
             "args": [
-              "io.cdap.cdap.master.upgrade.UpgradeJobMain",
+              "io.cdap.cdap.master.upgrade.PostUpgradeJobMain",
               "cdap-test-router",
-              "11015"
+              "11015",
+              "1581238669880"
             ],
             "image": "gcr.io/cloud-data-fusion-images/cloud-data-fusion:6.1.0.5",
             "imagePullPolicy": "IfNotPresent",
-            "name": "pre-upgrade",
+            "name": "post-upgrade",
             "resources": {},
             "terminationMessagePath": "/dev/termination-log",
             "terminationMessagePolicy": "File",

--- a/controllers/version_update.go
+++ b/controllers/version_update.go
@@ -162,7 +162,7 @@ func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, ob
 	if !isConditionTrue(master, updateStatus.PreUpgradeSucceeded) {
 		log.Printf("Version update: pre-upgrade job not completed")
 		preJobName := getPreUpgradeJobName(master.Status.UpgradeStartTimeMillis)
-		preJobSpec := buildUpgradeJobSpec(getPreUpgradeJobName(master.Status.UpgradeStartTimeMillis), master, labels)
+		preJobSpec := buildPreUpgradeJobSpec(getPreUpgradeJobName(master.Status.UpgradeStartTimeMillis), master, labels)
 		job := findJob(preJobName)
 		if job == nil {
 			obj, err := createJob(preJobSpec)
@@ -205,7 +205,7 @@ func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, ob
 	if !isConditionTrue(master, updateStatus.PostUpgradeSucceeded) {
 		log.Printf("Version update: post-upgrade job not completed")
 		postJobName := getPostUpgradeJobName(master.Status.UpgradeStartTimeMillis)
-		postJobSpec := buildUpgradeJobSpec(getPostUpgradeJobName(master.Status.UpgradeStartTimeMillis), master, labels)
+		postJobSpec := buildPostUpgradeJobSpec(getPostUpgradeJobName(master.Status.UpgradeStartTimeMillis), master, labels)
 		job := findJob(postJobName)
 		if job == nil {
 			obj, err := createJob(postJobSpec)
@@ -508,13 +508,22 @@ func getPostUpgradeJobName(startTimeMs int64) string {
 	return fmt.Sprintf("post-upgrade-job-%d", startTimeMs)
 }
 
-// Return upgrade job spec
-func buildUpgradeJobSpec(jobName string, master *v1alpha1.CDAPMaster, labels map[string]string) *VersionUpgradeJobSpec {
+// Return pre-upgrade job spec
+func buildPreUpgradeJobSpec(jobName string, master *v1alpha1.CDAPMaster, labels map[string]string) *VersionUpgradeJobSpec {
 	startTimeMs := master.Status.UpgradeStartTimeMillis
 	cconf := getObjName(master, configMapCConf)
 	hconf := getObjName(master, configMapHConf)
 	name := getObjName(master, jobName)
 	return newUpgradeJobSpec(master, name, labels, startTimeMs, cconf, hconf).SetPreUpgrade(true)
+}
+
+// Return post-upgrade job spec
+func buildPostUpgradeJobSpec(jobName string, master *v1alpha1.CDAPMaster, labels map[string]string) *VersionUpgradeJobSpec {
+	startTimeMs := master.Status.UpgradeStartTimeMillis
+	cconf := getObjName(master, configMapCConf)
+	hconf := getObjName(master, configMapHConf)
+	name := getObjName(master, jobName)
+	return newUpgradeJobSpec(master, name, labels, startTimeMs, cconf, hconf).SetPostUpgrade(true)
 }
 
 // Given an upgrade job spec, return a reconciler object as expected state

--- a/controllers/version_update_test.go
+++ b/controllers/version_update_test.go
@@ -180,7 +180,7 @@ var _ = Describe("Controller Suite", func() {
 			Expect(master.Status.UserInterfaceImageToUse).To(Equal(newUIImage))
 		})
 	})
-	Describe("Post upgrade job", func() {
+	Describe("Pre upgrade job", func() {
 		It("k8s object", func() {
 			const upgradeTimeMs int64 = 1581238669880
 			const newUIImage = "gcr.io/cloud-data-fusion-images/cloud-data-fusion:6.1.0.5"
@@ -199,7 +199,7 @@ var _ = Describe("Controller Suite", func() {
 					ImageToUse:             curUIImage,
 				},
 			}
-			postJobSpec := buildUpgradeJobSpec(getPreUpgradeJobName(master.Status.UpgradeStartTimeMillis), master, emptyLabels)
+			postJobSpec := buildPreUpgradeJobSpec(getPreUpgradeJobName(master.Status.UpgradeStartTimeMillis), master, emptyLabels)
 			object, err := buildUpgradeJobObject(postJobSpec)
 			Expect(err).To(BeNil())
 
@@ -230,7 +230,7 @@ var _ = Describe("Controller Suite", func() {
 					ImageToUse:             curUIImage,
 				},
 			}
-			postJobSpec := buildUpgradeJobSpec(getPostUpgradeJobName(master.Status.UpgradeStartTimeMillis), master, emptyLabels)
+			postJobSpec := buildPostUpgradeJobSpec(getPostUpgradeJobName(master.Status.UpgradeStartTimeMillis), master, emptyLabels)
 			object, err := buildUpgradeJobObject(postJobSpec)
 			Expect(err).To(BeNil())
 


### PR DESCRIPTION
Upgrade incorrectly runs pre-upgrade as well after image update, while it should run post-upgrade. 

Test didn't catch it due to copying and pasting test data. 

Fixing the test and code. 