### PR TITLE
Add a ConfigMapVolumes to allow operator mounting user provided configmaps

### DIFF
--- a/api/v1alpha1/cdapmaster_types.go
+++ b/api/v1alpha1/cdapmaster_types.go
@@ -46,6 +46,10 @@ type CDAPMasterSpec struct {
 	LocationURI string `json:"locationURI"`
 	// Config is a set of configurations that goes into cdap-site.xml.
 	Config map[string]string `json:"config,omitempty"`
+	// ConfigMapVolumes defines a map from ConfigMap names to volume mount path.
+	// Key is the configmap object name. Value is the mount path.
+	// This adds ConfigMap data to the directory specified by the volume mount path.
+	ConfigMapVolumes map[string]string `json:configMapVolumes,omitempty`
 	// SystemAppConfigs specifies configs used by CDAP to run system apps
 	// dynamically. Each entry is of format <filename, json app config> which will
 	// create a separate system config file with entry value as file content.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -135,6 +135,13 @@ func (in *CDAPMasterSpec) DeepCopyInto(out *CDAPMasterSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.ConfigMapVolumes != nil {
+		in, out := &in.ConfigMapVolumes, &out.ConfigMapVolumes
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.SystemAppConfigs != nil {
 		in, out := &in.SystemAppConfigs, &out.SystemAppConfigs
 		*out = make(map[string]string, len(*in))

--- a/controllers/spec.go
+++ b/controllers/spec.go
@@ -132,6 +132,7 @@ type BaseSpec struct {
 	CConf              string            `json:"cdapConf,omitempty"`
 	HConf              string            `json:"hadoopConf,omitempty"`
 	SysAppConf         string            `json:"sysAppConf,omitempty"`
+	ConfigMapVolumes   map[string]string `json:"configMapVolumes,omitempty"`
 }
 
 func newBaseSpec(master *v1alpha1.CDAPMaster, name string, labels map[string]string, cconf, hconf, sysappconf string) *BaseSpec {
@@ -147,6 +148,7 @@ func newBaseSpec(master *v1alpha1.CDAPMaster, name string, labels map[string]str
 	s.CConf = cconf
 	s.HConf = hconf
 	s.SysAppConf = sysappconf
+	s.ConfigMapVolumes = master.Spec.ConfigMapVolumes
 	return s
 }
 

--- a/controllers/testdata/appfabric.json
+++ b/controllers/testdata/appfabric.json
@@ -119,6 +119,14 @@
                 "mountPath": "/etc/cdap/security",
                 "name": "cdap-security",
                 "readOnly": true
+              },
+              {
+                "name": "cdap-config-map-volumes-my-config-map-1",
+                "mountPath": "/my/config/map/1"
+              },
+              {
+                "mountPath": "/my/config/map/2",
+                "name": "cdap-config-map-volumes-my-config-map-2"
               }
             ]
           }
@@ -160,6 +168,14 @@
                 "name": "cdap-security",
                 "readOnly": true,
                 "mountPath": "/etc/cdap/security"
+              },
+              {
+                "name": "cdap-config-map-volumes-my-config-map-1",
+                "mountPath": "/my/config/map/1"
+              },
+              {
+                "mountPath": "/my/config/map/2",
+                "name": "cdap-config-map-volumes-my-config-map-2"
               }
             ]
           }
@@ -220,6 +236,20 @@
             "secret": {
               "defaultMode": 420,
               "secretName": "cdap-secret"
+            }
+          },
+          {
+            "name": "cdap-config-map-volumes-my-config-map-1",
+            "configMap": {
+              "defaultMode": 420,
+              "name": "my-config-map-1"
+            }
+          },
+          {
+            "name": "cdap-config-map-volumes-my-config-map-2",
+            "configMap": {
+              "defaultMode": 420,
+              "name": "my-config-map-2"
             }
           }
         ]

--- a/controllers/testdata/cdap_master_cr.json
+++ b/controllers/testdata/cdap_master_cr.json
@@ -45,6 +45,10 @@
       "router.bind.port": "11015",
       "router.server.address": "cdap-test-router"
     },
+    "configMapVolumes": {
+      "my-config-map-1": "/my/config/map/1",
+      "my-config-map-2": "/my/config/map/2"
+    },
     "image": "gcr.io/cloud-data-fusion-images/cloud-data-fusion:6.1.0.5",
     "locationURI": "hdfs://hadoop:9000",
     "logs": {

--- a/controllers/testdata/logs.json
+++ b/controllers/testdata/logs.json
@@ -108,6 +108,14 @@
                 "mountPath": "/etc/cdap/security",
                 "name": "cdap-security",
                 "readOnly": true
+              },
+              {
+                "name": "cdap-config-map-volumes-my-config-map-1",
+                "mountPath": "/my/config/map/1"
+              },
+              {
+                "mountPath": "/my/config/map/2",
+                "name": "cdap-config-map-volumes-my-config-map-2"
               }
             ]
           }
@@ -153,6 +161,14 @@
                 "mountPath": "/etc/cdap/security",
                 "name": "cdap-security",
                 "readOnly": true
+              },
+              {
+                "name": "cdap-config-map-volumes-my-config-map-1",
+                "mountPath": "/my/config/map/1"
+              },
+              {
+                "mountPath": "/my/config/map/2",
+                "name": "cdap-config-map-volumes-my-config-map-2"
               }
             ]
           }
@@ -212,6 +228,20 @@
             "secret": {
               "defaultMode": 420,
               "secretName": "cdap-secret"
+            }
+          },
+          {
+            "name": "cdap-config-map-volumes-my-config-map-1",
+            "configMap": {
+              "defaultMode": 420,
+              "name": "my-config-map-1"
+            }
+          },
+          {
+            "name": "cdap-config-map-volumes-my-config-map-2",
+            "configMap": {
+              "defaultMode": 420,
+              "name": "my-config-map-2"
             }
           }
         ]

--- a/controllers/testdata/messaging.json
+++ b/controllers/testdata/messaging.json
@@ -108,6 +108,14 @@
                 "mountPath": "/etc/cdap/security",
                 "name": "cdap-security",
                 "readOnly": true
+              },
+              {
+                "name": "cdap-config-map-volumes-my-config-map-1",
+                "mountPath": "/my/config/map/1"
+              },
+              {
+                "mountPath": "/my/config/map/2",
+                "name": "cdap-config-map-volumes-my-config-map-2"
               }
             ]
           }
@@ -153,6 +161,14 @@
                 "mountPath": "/etc/cdap/security",
                 "name": "cdap-security",
                 "readOnly": true
+              },
+              {
+                "name": "cdap-config-map-volumes-my-config-map-1",
+                "mountPath": "/my/config/map/1"
+              },
+              {
+                "mountPath": "/my/config/map/2",
+                "name": "cdap-config-map-volumes-my-config-map-2"
               }
             ]
           }
@@ -212,6 +228,20 @@
             "secret": {
               "defaultMode": 420,
               "secretName": "cdap-secret"
+            }
+          },
+          {
+            "name": "cdap-config-map-volumes-my-config-map-1",
+            "configMap": {
+              "defaultMode": 420,
+              "name": "my-config-map-1"
+            }
+          },
+          {
+            "name": "cdap-config-map-volumes-my-config-map-2",
+            "configMap": {
+              "defaultMode": 420,
+              "name": "my-config-map-2"
             }
           }
         ]

--- a/controllers/testdata/metadata.json
+++ b/controllers/testdata/metadata.json
@@ -119,6 +119,14 @@
                 "mountPath": "/etc/cdap/security",
                 "name": "cdap-security",
                 "readOnly": true
+              },
+              {
+                "name": "cdap-config-map-volumes-my-config-map-1",
+                "mountPath": "/my/config/map/1"
+              },
+              {
+                "mountPath": "/my/config/map/2",
+                "name": "cdap-config-map-volumes-my-config-map-2"
               }
             ]
           }
@@ -160,6 +168,14 @@
                 "name": "cdap-security",
                 "readOnly": true,
                 "mountPath": "/etc/cdap/security"
+              },
+              {
+                "name": "cdap-config-map-volumes-my-config-map-1",
+                "mountPath": "/my/config/map/1"
+              },
+              {
+                "mountPath": "/my/config/map/2",
+                "name": "cdap-config-map-volumes-my-config-map-2"
               }
             ]
           }
@@ -221,6 +237,18 @@
               "defaultMode": 420,
               "secretName": "cdap-secret"
             }
+          },
+          {
+            "name": "cdap-config-map-volumes-my-config-map-1",
+            "configMap": {
+              "name": "my-config-map-1"
+            }
+          },
+          {
+            "configMap": {
+              "name": "my-config-map-2"
+            },
+            "name": "cdap-config-map-volumes-my-config-map-2"
           }
         ]
       }

--- a/controllers/testdata/metrics.json
+++ b/controllers/testdata/metrics.json
@@ -108,6 +108,14 @@
                 "mountPath": "/etc/cdap/security",
                 "name": "cdap-security",
                 "readOnly": true
+              },
+              {
+                "name": "cdap-config-map-volumes-my-config-map-1",
+                "mountPath": "/my/config/map/1"
+              },
+              {
+                "mountPath": "/my/config/map/2",
+                "name": "cdap-config-map-volumes-my-config-map-2"
               }
             ]
           }
@@ -153,6 +161,14 @@
                 "mountPath": "/etc/cdap/security",
                 "name": "cdap-security",
                 "readOnly": true
+              },
+              {
+                "name": "cdap-config-map-volumes-my-config-map-1",
+                "mountPath": "/my/config/map/1"
+              },
+              {
+                "mountPath": "/my/config/map/2",
+                "name": "cdap-config-map-volumes-my-config-map-2"
               }
             ]
           }
@@ -212,6 +228,20 @@
             "secret": {
               "defaultMode": 420,
               "secretName": "cdap-secret"
+            }
+          },
+          {
+            "name": "cdap-config-map-volumes-my-config-map-1",
+            "configMap": {
+              "defaultMode": 420,
+              "name": "my-config-map-1"
+            }
+          },
+          {
+            "name": "cdap-config-map-volumes-my-config-map-2",
+            "configMap": {
+              "defaultMode": 420,
+              "name": "my-config-map-2"
             }
           }
         ]

--- a/controllers/testdata/preview.json
+++ b/controllers/testdata/preview.json
@@ -108,6 +108,14 @@
                 "mountPath": "/etc/cdap/security",
                 "name": "cdap-security",
                 "readOnly": true
+              },
+              {
+                "name": "cdap-config-map-volumes-my-config-map-1",
+                "mountPath": "/my/config/map/1"
+              },
+              {
+                "name": "cdap-config-map-volumes-my-config-map-2",
+                "mountPath": "/my/config/map/2"
               }
             ]
           }
@@ -153,6 +161,14 @@
                 "mountPath": "/etc/cdap/security",
                 "name": "cdap-security",
                 "readOnly": true
+              },
+              {
+                "name": "cdap-config-map-volumes-my-config-map-1",
+                "mountPath": "/my/config/map/1"
+              },
+              {
+                "name": "cdap-config-map-volumes-my-config-map-2",
+                "mountPath": "/my/config/map/2"
               }
             ]
           }
@@ -212,6 +228,18 @@
             "secret": {
               "defaultMode": 420,
               "secretName": "cdap-secret"
+            }
+          },
+          {
+            "name": "cdap-config-map-volumes-my-config-map-1",
+            "configMap": {
+              "name": "my-config-map-1"
+            }
+          },
+          {
+            "name": "cdap-config-map-volumes-my-config-map-2",
+            "configMap": {
+              "name": "my-config-map-2"
             }
           }
         ]

--- a/controllers/testdata/router.json
+++ b/controllers/testdata/router.json
@@ -113,6 +113,14 @@
                 "mountPath": "/etc/cdap/security",
                 "name": "cdap-security",
                 "readOnly": true
+              },
+              {
+                "mountPath": "/my/config/map/1",
+                "name": "cdap-config-map-volumes-k"
+              },
+              {
+                "name": "cdap-config-map-volumes-k",
+                "mountPath": "/my/config/map/2"
               }
             ]
           }
@@ -173,6 +181,18 @@
             "secret": {
               "defaultMode": 420,
               "secretName": "cdap-secret"
+            }
+          },
+          {
+            "name": "cdap-config-map-volumes-my-config-map-1",
+            "configMap": {
+              "name": "my-config-map-1"
+            }
+          },
+          {
+            "name": "cdap-config-map-volumes-my-config-map-2",
+            "configMap": {
+              "name": "my-config-map-2"
             }
           }
         ]

--- a/controllers/testdata/runtime.json
+++ b/controllers/testdata/runtime.json
@@ -119,6 +119,14 @@
                 "mountPath": "/etc/cdap/security",
                 "name": "cdap-security",
                 "readOnly": true
+              },
+              {
+                "name": "cdap-config-map-volumes-my-config-map-1",
+                "mountPath": "/my/config/map/1"
+              },
+              {
+                "name": "cdap-config-map-volumes-my-config-map-2",
+                "mountPath": "/my/config/map/2"
               }
             ]
           }
@@ -160,6 +168,14 @@
                 "name": "cdap-security",
                 "readOnly": true,
                 "mountPath": "/etc/cdap/security"
+              },
+              {
+                "name": "cdap-config-map-volumes-my-config-map-1",
+                "mountPath": "/my/config/map/1"
+              },
+              {
+                "name": "cdap-config-map-volumes-my-config-map-2",
+                "mountPath": "/my/config/map/2"
               }
             ]
           }
@@ -220,6 +236,18 @@
             "secret": {
               "defaultMode": 420,
               "secretName": "cdap-secret"
+            }
+          },
+          {
+            "name": "cdap-config-map-volumes-my-config-map-1",
+            "configMap": {
+              "name": "my-config-map-1"
+            }
+          },
+          {
+            "name": "cdap-config-map-volumes-my-config-map-2",
+            "configMap": {
+              "name": "my-config-map-2"
             }
           }
         ]

--- a/controllers/testdata/userinterface.json
+++ b/controllers/testdata/userinterface.json
@@ -120,6 +120,14 @@
                 "mountPath": "/etc/cdap/security",
                 "name": "cdap-security",
                 "readOnly": true
+              },
+              {
+                "name": "cdap-config-map-volumes-k",
+                "mountPath": "/my/config/map/1"
+              },
+              {
+                "name": "cdap-config-map-volumes-k",
+                "mountPath": "/my/config/map/2"
               }
             ],
             "workingDir": "/opt/cdap/ui"
@@ -181,6 +189,18 @@
             "secret": {
               "defaultMode": 420,
               "secretName": "cdap-secret"
+            }
+          },
+          {
+            "configMap": {
+              "name": "my-config-map-1"
+            },
+            "name": "cdap-config-map-volumes-my-config-map-1"
+          },
+          {
+            "name": "cdap-config-map-volumes-my-config-map-2",
+            "configMap": {
+              "name": "my-config-map-2"
             }
           }
         ]

--- a/templates/cdap-deployment.yaml
+++ b/templates/cdap-deployment.yaml
@@ -102,6 +102,10 @@ spec:
               mountPath: /etc/cdap/security
               readOnly: true
             {{end}}
+            {{range $k,$v := $.Base.ConfigMapVolumes}}
+            - name: cdap-config-map-volumes-k
+              mountPath: {{$v}}
+            {{end}}
       {{end}}
       volumes:
         - name: podinfo
@@ -126,4 +130,9 @@ spec:
         - name: cdap-security
           secret:
             secretName: {{.Base.SecuritySecret}}
+        {{end}}
+        {{range $k,$v := $.Base.ConfigMapVolumes}}
+        - name: cdap-config-map-volumes-{{$k}}
+          configMap:
+            name: {{$k}}
         {{end}}

--- a/templates/cdap-sts.yaml
+++ b/templates/cdap-sts.yaml
@@ -137,7 +137,11 @@ spec:
             - name: cdap-security
               mountPath: /etc/cdap/security
               readOnly: true
-          {{end}}
+            {{end}}
+            {{range $k,$v := $.Base.ConfigMapVolumes}}
+            - name: cdap-config-map-volumes-{{$k}}
+              mountPath: {{$v}}
+            {{end}}
       {{end}}
       volumes:
         - name: podinfo
@@ -162,6 +166,11 @@ spec:
         - name: cdap-security
           secret:
             secretName: {{$.Base.SecuritySecret}}
+        {{end}}
+        {{range $k,$v := $.Base.ConfigMapVolumes}}
+        - name: cdap-config-map-volumes-{{$k}}
+          configMap:
+            name: {{$k}}
         {{end}}
   volumeClaimTemplates:
   - metadata:


### PR DESCRIPTION
Why:
For use case where, user would like to set up a number of configurations
(e.g. bootstrap file) before head. Then instruct CDAP operator to mount
these configs in service containers.

What:
This change introduce a map: k8s ConfigMap object name  -> mount path
in CDAPMaster CRD.

How to use:
1) set up configmap yourself
e.g
NAME                  DATA   AGE
some-conf             3      4h22m
more-conf             3      1h00m
2) set ConfigMapVolumes to
ConfigMapVolumes[some-conf]="/paht/to/mount/some/conf"
ConfigMapVolumes[more-conf]="/path/to/mount/more/conf"

Then access data from container like
/path/to/mount/some/conf/<data1>
...