### PR TITLE
Fix missing "env" in statefulset yaml template.

### DIFF
--- a/templates/cdap-sts.yaml
+++ b/templates/cdap-sts.yaml
@@ -104,7 +104,11 @@ spec:
           {{if $c.ImagePullPolicy}}
           imagePullPolicy: {{$c.ImagePullPolicy}}
           {{end}}
-          env: []
+          env:
+          {{range $e := $c.Env }}
+          - name: "{{$e.Name}}"
+            value: "{{$e.Value}}"
+          {{end}}
           resources:
             {{if $c.ResourceRequests}}
             requests:


### PR DESCRIPTION
Bug:
Statefulset yaml template always sets env to emtpy, as a result
we fail to set jvm heap size for all statefulset services