### PR TITLE
Shorten the volume name to avoid exceeding 63 char limit

### DIFF
--- a/controllers/testdata/appfabric.json
+++ b/controllers/testdata/appfabric.json
@@ -121,12 +121,12 @@
                 "readOnly": true
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-1",
+                "name": "cdap-cm-vol-my-config-map-1",
                 "mountPath": "/my/config/map/1"
               },
               {
                 "mountPath": "/my/config/map/2",
-                "name": "cdap-config-map-volumes-my-config-map-2"
+                "name": "cdap-cm-vol-my-config-map-2"
               }
             ]
           }
@@ -170,12 +170,12 @@
                 "mountPath": "/etc/cdap/security"
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-1",
+                "name": "cdap-cm-vol-my-config-map-1",
                 "mountPath": "/my/config/map/1"
               },
               {
                 "mountPath": "/my/config/map/2",
-                "name": "cdap-config-map-volumes-my-config-map-2"
+                "name": "cdap-cm-vol-my-config-map-2"
               }
             ]
           }
@@ -239,14 +239,14 @@
             }
           },
           {
-            "name": "cdap-config-map-volumes-my-config-map-1",
+            "name": "cdap-cm-vol-my-config-map-1",
             "configMap": {
               "defaultMode": 420,
               "name": "my-config-map-1"
             }
           },
           {
-            "name": "cdap-config-map-volumes-my-config-map-2",
+            "name": "cdap-cm-vol-my-config-map-2",
             "configMap": {
               "defaultMode": 420,
               "name": "my-config-map-2"

--- a/controllers/testdata/logs.json
+++ b/controllers/testdata/logs.json
@@ -110,12 +110,12 @@
                 "readOnly": true
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-1",
+                "name": "cdap-cm-vol-my-config-map-1",
                 "mountPath": "/my/config/map/1"
               },
               {
                 "mountPath": "/my/config/map/2",
-                "name": "cdap-config-map-volumes-my-config-map-2"
+                "name": "cdap-cm-vol-my-config-map-2"
               }
             ]
           }
@@ -163,12 +163,12 @@
                 "readOnly": true
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-1",
+                "name": "cdap-cm-vol-my-config-map-1",
                 "mountPath": "/my/config/map/1"
               },
               {
                 "mountPath": "/my/config/map/2",
-                "name": "cdap-config-map-volumes-my-config-map-2"
+                "name": "cdap-cm-vol-my-config-map-2"
               }
             ]
           }
@@ -231,14 +231,14 @@
             }
           },
           {
-            "name": "cdap-config-map-volumes-my-config-map-1",
+            "name": "cdap-cm-vol-my-config-map-1",
             "configMap": {
               "defaultMode": 420,
               "name": "my-config-map-1"
             }
           },
           {
-            "name": "cdap-config-map-volumes-my-config-map-2",
+            "name": "cdap-cm-vol-my-config-map-2",
             "configMap": {
               "defaultMode": 420,
               "name": "my-config-map-2"

--- a/controllers/testdata/messaging.json
+++ b/controllers/testdata/messaging.json
@@ -110,12 +110,12 @@
                 "readOnly": true
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-1",
+                "name": "cdap-cm-vol-my-config-map-1",
                 "mountPath": "/my/config/map/1"
               },
               {
                 "mountPath": "/my/config/map/2",
-                "name": "cdap-config-map-volumes-my-config-map-2"
+                "name": "cdap-cm-vol-my-config-map-2"
               }
             ]
           }
@@ -163,12 +163,12 @@
                 "readOnly": true
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-1",
+                "name": "cdap-cm-vol-my-config-map-1",
                 "mountPath": "/my/config/map/1"
               },
               {
                 "mountPath": "/my/config/map/2",
-                "name": "cdap-config-map-volumes-my-config-map-2"
+                "name": "cdap-cm-vol-my-config-map-2"
               }
             ]
           }
@@ -231,14 +231,14 @@
             }
           },
           {
-            "name": "cdap-config-map-volumes-my-config-map-1",
+            "name": "cdap-cm-vol-my-config-map-1",
             "configMap": {
               "defaultMode": 420,
               "name": "my-config-map-1"
             }
           },
           {
-            "name": "cdap-config-map-volumes-my-config-map-2",
+            "name": "cdap-cm-vol-my-config-map-2",
             "configMap": {
               "defaultMode": 420,
               "name": "my-config-map-2"

--- a/controllers/testdata/metadata.json
+++ b/controllers/testdata/metadata.json
@@ -121,12 +121,12 @@
                 "readOnly": true
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-1",
+                "name": "cdap-cm-vol-my-config-map-1",
                 "mountPath": "/my/config/map/1"
               },
               {
                 "mountPath": "/my/config/map/2",
-                "name": "cdap-config-map-volumes-my-config-map-2"
+                "name": "cdap-cm-vol-my-config-map-2"
               }
             ]
           }
@@ -170,12 +170,12 @@
                 "mountPath": "/etc/cdap/security"
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-1",
+                "name": "cdap-cm-vol-my-config-map-1",
                 "mountPath": "/my/config/map/1"
               },
               {
                 "mountPath": "/my/config/map/2",
-                "name": "cdap-config-map-volumes-my-config-map-2"
+                "name": "cdap-cm-vol-my-config-map-2"
               }
             ]
           }
@@ -239,7 +239,7 @@
             }
           },
           {
-            "name": "cdap-config-map-volumes-my-config-map-1",
+            "name": "cdap-cm-vol-my-config-map-1",
             "configMap": {
               "name": "my-config-map-1"
             }
@@ -248,7 +248,7 @@
             "configMap": {
               "name": "my-config-map-2"
             },
-            "name": "cdap-config-map-volumes-my-config-map-2"
+            "name": "cdap-cm-vol-my-config-map-2"
           }
         ]
       }

--- a/controllers/testdata/metrics.json
+++ b/controllers/testdata/metrics.json
@@ -110,12 +110,12 @@
                 "readOnly": true
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-1",
+                "name": "cdap-cm-vol-my-config-map-1",
                 "mountPath": "/my/config/map/1"
               },
               {
                 "mountPath": "/my/config/map/2",
-                "name": "cdap-config-map-volumes-my-config-map-2"
+                "name": "cdap-cm-vol-my-config-map-2"
               }
             ]
           }
@@ -163,12 +163,12 @@
                 "readOnly": true
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-1",
+                "name": "cdap-cm-vol-my-config-map-1",
                 "mountPath": "/my/config/map/1"
               },
               {
                 "mountPath": "/my/config/map/2",
-                "name": "cdap-config-map-volumes-my-config-map-2"
+                "name": "cdap-cm-vol-my-config-map-2"
               }
             ]
           }
@@ -231,14 +231,14 @@
             }
           },
           {
-            "name": "cdap-config-map-volumes-my-config-map-1",
+            "name": "cdap-cm-vol-my-config-map-1",
             "configMap": {
               "defaultMode": 420,
               "name": "my-config-map-1"
             }
           },
           {
-            "name": "cdap-config-map-volumes-my-config-map-2",
+            "name": "cdap-cm-vol-my-config-map-2",
             "configMap": {
               "defaultMode": 420,
               "name": "my-config-map-2"

--- a/controllers/testdata/preview.json
+++ b/controllers/testdata/preview.json
@@ -110,11 +110,11 @@
                 "readOnly": true
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-1",
+                "name": "cdap-cm-vol-my-config-map-1",
                 "mountPath": "/my/config/map/1"
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-2",
+                "name": "cdap-cm-vol-my-config-map-2",
                 "mountPath": "/my/config/map/2"
               }
             ]
@@ -163,11 +163,11 @@
                 "readOnly": true
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-1",
+                "name": "cdap-cm-vol-my-config-map-1",
                 "mountPath": "/my/config/map/1"
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-2",
+                "name": "cdap-cm-vol-my-config-map-2",
                 "mountPath": "/my/config/map/2"
               }
             ]
@@ -231,13 +231,13 @@
             }
           },
           {
-            "name": "cdap-config-map-volumes-my-config-map-1",
+            "name": "cdap-cm-vol-my-config-map-1",
             "configMap": {
               "name": "my-config-map-1"
             }
           },
           {
-            "name": "cdap-config-map-volumes-my-config-map-2",
+            "name": "cdap-cm-vol-my-config-map-2",
             "configMap": {
               "name": "my-config-map-2"
             }

--- a/controllers/testdata/router.json
+++ b/controllers/testdata/router.json
@@ -116,10 +116,10 @@
               },
               {
                 "mountPath": "/my/config/map/1",
-                "name": "cdap-config-map-volumes-my-config-map-1"
+                "name": "cdap-cm-vol-my-config-map-1"
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-2",
+                "name": "cdap-cm-vol-my-config-map-2",
                 "mountPath": "/my/config/map/2"
               }
             ]
@@ -184,13 +184,13 @@
             }
           },
           {
-            "name": "cdap-config-map-volumes-my-config-map-1",
+            "name": "cdap-cm-vol-my-config-map-1",
             "configMap": {
               "name": "my-config-map-1"
             }
           },
           {
-            "name": "cdap-config-map-volumes-my-config-map-2",
+            "name": "cdap-cm-vol-my-config-map-2",
             "configMap": {
               "name": "my-config-map-2"
             }

--- a/controllers/testdata/runtime.json
+++ b/controllers/testdata/runtime.json
@@ -121,11 +121,11 @@
                 "readOnly": true
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-1",
+                "name": "cdap-cm-vol-my-config-map-1",
                 "mountPath": "/my/config/map/1"
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-2",
+                "name": "cdap-cm-vol-my-config-map-2",
                 "mountPath": "/my/config/map/2"
               }
             ]
@@ -170,11 +170,11 @@
                 "mountPath": "/etc/cdap/security"
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-1",
+                "name": "cdap-cm-vol-my-config-map-1",
                 "mountPath": "/my/config/map/1"
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-2",
+                "name": "cdap-cm-vol-my-config-map-2",
                 "mountPath": "/my/config/map/2"
               }
             ]
@@ -239,13 +239,13 @@
             }
           },
           {
-            "name": "cdap-config-map-volumes-my-config-map-1",
+            "name": "cdap-cm-vol-my-config-map-1",
             "configMap": {
               "name": "my-config-map-1"
             }
           },
           {
-            "name": "cdap-config-map-volumes-my-config-map-2",
+            "name": "cdap-cm-vol-my-config-map-2",
             "configMap": {
               "name": "my-config-map-2"
             }

--- a/controllers/testdata/userinterface.json
+++ b/controllers/testdata/userinterface.json
@@ -122,11 +122,11 @@
                 "readOnly": true
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-1",
+                "name": "cdap-cm-vol-my-config-map-1",
                 "mountPath": "/my/config/map/1"
               },
               {
-                "name": "cdap-config-map-volumes-my-config-map-2",
+                "name": "cdap-cm-vol-my-config-map-2",
                 "mountPath": "/my/config/map/2"
               }
             ],
@@ -195,10 +195,10 @@
             "configMap": {
               "name": "my-config-map-1"
             },
-            "name": "cdap-config-map-volumes-my-config-map-1"
+            "name": "cdap-cm-vol-my-config-map-1"
           },
           {
-            "name": "cdap-config-map-volumes-my-config-map-2",
+            "name": "cdap-cm-vol-my-config-map-2",
             "configMap": {
               "name": "my-config-map-2"
             }

--- a/templates/cdap-deployment.yaml
+++ b/templates/cdap-deployment.yaml
@@ -103,7 +103,7 @@ spec:
               readOnly: true
             {{end}}
             {{range $k,$v := $.Base.ConfigMapVolumes}}
-            - name: cdap-config-map-volumes-{{$k}}
+            - name: cdap-cm-vol-{{$k}}
               mountPath: {{$v}}
             {{end}}
       {{end}}
@@ -132,7 +132,7 @@ spec:
             secretName: {{.Base.SecuritySecret}}
         {{end}}
         {{range $k,$v := $.Base.ConfigMapVolumes}}
-        - name: cdap-config-map-volumes-{{$k}}
+        - name: cdap-cm-vol-{{$k}}
           configMap:
             name: {{$k}}
         {{end}}

--- a/templates/cdap-sts.yaml
+++ b/templates/cdap-sts.yaml
@@ -143,7 +143,7 @@ spec:
               readOnly: true
             {{end}}
             {{range $k,$v := $.Base.ConfigMapVolumes}}
-            - name: cdap-config-map-volumes-{{$k}}
+            - name: cdap-cm-vol-{{$k}}
               mountPath: {{$v}}
             {{end}}
       {{end}}
@@ -172,7 +172,7 @@ spec:
             secretName: {{$.Base.SecuritySecret}}
         {{end}}
         {{range $k,$v := $.Base.ConfigMapVolumes}}
-        - name: cdap-config-map-volumes-{{$k}}
+        - name: cdap-cm-vol-{{$k}}
           configMap:
             name: {{$k}}
         {{end}}


### PR DESCRIPTION
when configmap name is long

Why:
cdap-config-map-volumes-<configmap_name>
When configmap_name is long, the overall name length could
exceed 63 limit, eg
cdap-config-map-volumes-cdap-ttt53smsruakai6vidsaanbcpj6ei1-configmap