### PR TITLE
Bump JVM non-heap memory to 768MB to 1GB

### DIFF
--- a/pkg/controller/cdapmaster/cdapmaster_controller.go
+++ b/pkg/controller/cdapmaster/cdapmaster_controller.go
@@ -41,7 +41,7 @@ const (
 	containerLabel = "cdap.container"
 	// Heap memory related constants
 	javaMinHeapRatio     = float64(0.6)
-	javaReservedNonHeap  = int64(768 * 1024 * 1024)
+	javaReservedNonHeap  = int64(1024 * 1024 * 1024)
 	templateDir          = "templates/"
 	deploymentTemplate   = "cdap-deployment.yaml"
 	uiDeploymentTemplate = "cdap-ui-deployment.yaml"


### PR DESCRIPTION
Why:
We have observed that 768MB could be insufficient and lead to
cannot allocate meomry error when CDAP backend is under load and
there are concurrent pipeline runs (copying artifacts uses direct
buffer), therefore bumping up non-heap memory reserve to mitigate
the issue.