### PR TITLE
Bump JVM non-heap memory to 768MB to 1GB

### DIFF
--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -85,7 +85,7 @@ const (
 
 	// Java heap size
 	javaMinHeapRatio          = float64(0.6)
-	javaReservedNonHeap       = int64(768 * 1024 * 1024)
+	javaReservedNonHeap       = int64(1024 * 1024 * 1024)
 	javaMaxHeapSizeEnvVarName = "JAVA_HEAPMAX"
 
 	Bytes     = int64(1)


### PR DESCRIPTION
Why:
We have observed that 768MB could be insufficient and lead to
cannot allocate meomry error when CDAP backend is under load and
there are concurrent pipeline runs (copying artifacts uses direct
buffer), therefore bumping up non-heap memory reserve to mitigate
the issue.