### PR TITLE
Bump up upgrade max tries from 4 to 10.

### DIFF
--- a/pkg/controller/cdapmaster/cdapmaster_controller.go
+++ b/pkg/controller/cdapmaster/cdapmaster_controller.go
@@ -58,7 +58,7 @@ const (
 	upgradeJobFinishedMessage = "Upgrade job finished."
 	upgradeJobSkippedMessage  = "Upgrade job skipped."
 	upgradeResetMessage       = "Upgrade spec reset."
-	upgradeFailureLimit       = 4
+	upgradeFailureLimit       = 10
 
 	latestVersion = "latest"
 )


### PR DESCRIPTION
Why:
When cdap operator gets upgraded (e.g 1.0.0 to 1.0.1), the new
cdap operator might update deployment or statefulset that could
cause service (e.g. appfab) pod to restart. If CDAP image version
upgrade gets kicked off immediately after, pre upgrade job may
not be able to succeed till AppFabric pod is ready, which could
be ~5 mins. With a timeout of 1 mins and max retries of 4,
pre-upgrade job may not have a chance to succeed. Increase
the max retries to 10 to allow more time for preupgrade job
to be able to succeed