### PR TITLE
increase activeDeadlineSeconds setting for pre/post upgrade job to 6h and increasing retries to 20

### DIFF
--- a/pkg/controller/cdapmaster/cdapmaster_controller.go
+++ b/pkg/controller/cdapmaster/cdapmaster_controller.go
@@ -58,7 +58,12 @@ const (
 	upgradeJobFinishedMessage = "Upgrade job finished."
 	upgradeJobSkippedMessage  = "Upgrade job skipped."
 	upgradeResetMessage       = "Upgrade spec reset."
-	upgradeFailureLimit       = 10
+
+	// Have a high number of retry count to increase the chance of pre-/post- upgrade job succeeding,
+	// because for instance it may take a while for CDAP services to be fully up after pods being restarted
+	// following image version update, thus pre/post-upgrade job may have to be retried a number of times before
+	// it can actually communicate with CDAP services.
+	upgradeFailureLimit       = 20
 
 	latestVersion = "latest"
 )

--- a/templates/upgrade-job.yaml
+++ b/templates/upgrade-job.yaml
@@ -73,5 +73,8 @@ spec:
       {{end}}
       restartPolicy: Never
   backoffLimit: {{.Job.BackoffLimit}}
-  activeDeadlineSeconds: 600
+  # Set job deadline to 6h as pre/post upgrade job can take a lot of time to complete in scenarios like instance with
+  # many jobs, streaming jobs running etc. pre/post upgrade job should finish way before in most scenarios with their
+  # retries.
+  activeDeadlineSeconds: 21600
   ttlSecondsAfterFinished: 1200


### PR DESCRIPTION
Increased activeDeadlineSeconds parameter for upgrade job configuration to 6h to have an upper bound on job runtime but it should not be possible for upgrade job to reach this time. Something seriously would have gone wrong if upgrade job retries are not exhausted before 6h deadline.

Also increased number of retry counts for pre and post upgrade job to 20 as for a CDAP cluster with many jobs running/streaming jobs running, it might take a long time to stop them.