### PR TITLE
allow http port in image name

### DIFF
--- a/controllers/version_update.go
+++ b/controllers/version_update.go
@@ -372,18 +372,19 @@ func parseImageString(imageString string) (*Version, error) {
 		return &Version{}, nil
 	}
 	splits := strings.Split(imageString, ":")
-	if len(splits) != 2 {
-		return nil, fmt.Errorf("failed to parse image string %s, not in expected format of xxx:xxx", imageString)
+	if len(splits) > 3 {
+		return nil, fmt.Errorf("failed to parse image string %s, not in expected format of <domain>:<tag> or <domain>:<port>:<tag>, accepted tag versions : latest or X.X.X format", imageString)
 	}
 
-	if splits[1] == imageVersionLatest {
+	versionString := splits[len(splits)-1]
+
+	if versionString == imageVersionLatest {
 		return &Version{
 			rawString: imageString,
 			latest:    true,
 		}, nil
 	}
 
-	versionString := splits[1]
 	splits = strings.Split(versionString, ".")
 
 	var components []int

--- a/controllers/version_update_test.go
+++ b/controllers/version_update_test.go
@@ -17,12 +17,27 @@ import (
 
 var _ = Describe("Controller Suite", func() {
 	Describe("Parsing image string", func() {
-		It("Parse empty image string", func() {
+		It("Parse empty image string with http port", func() {
 			image := ""
 			version, err := parseImageString(image)
 			Expect(err).To(BeNil())
 			Expect(image).To(Equal(version.rawString))
 			Expect(version.latest).To(BeFalse())
+		})
+		It("Parse image string with http port", func() {
+			image := "gcr.io:1337/cdapio/cdap:latest"
+			version, err := parseImageString(image)
+			Expect(err).To(BeNil())
+			Expect(image).To(Equal(version.rawString))
+			Expect(version.latest).To(BeTrue())
+		})
+		It("Parse image string with http port and not latest tag", func() {
+			image := "gcr.io:1337/cdapio/cdap:1.3.3.7"
+			version, err := parseImageString(image)
+			Expect(err).To(BeNil())
+			Expect(image).To(Equal(version.rawString))
+			Expect(version.latest).To(BeFalse())
+			Expect(version.components).To(Equal([]int{1, 3, 3, 7}))
 		})
 		It("Parse latest image string", func() {
 			image := "gcr.io/cdapio/cdap:latest"


### PR DESCRIPTION
Adding an http port to cdap container image failed, due to array spliting limitation.

Ex : gcr.io:1337/cdapio/cdap:1.3.3.7