### PR TITLE
Set proper default value when local.data.dir is not specified

### DIFF
--- a/controllers/cdapmaster_controller.go
+++ b/controllers/cdapmaster_controller.go
@@ -130,7 +130,7 @@ func ApplyDefaults(resource interface{}) {
 
 	// Set the default local data directory if it is not set in cdap-cr.
 	if _, ok := spec.Config[confLocalDataDirKey]; !ok {
-		spec.Config[confLocalDataDirKey] = spec.Config[confLocalDataDirVal]
+		spec.Config[confLocalDataDirKey] = confLocalDataDirVal
 	}
 
 	// Disable explore


### PR DESCRIPTION
Cherry-pick of #67.