### PR TITLE
[CDAP-18079] Improve SecuritySecret CConf Consistency

### DIFF
--- a/controllers/cdapmaster_controller.go
+++ b/controllers/cdapmaster_controller.go
@@ -133,6 +133,11 @@ func ApplyDefaults(resource interface{}) {
 		spec.Config[confLocalDataDirKey] = confLocalDataDirVal
 	}
 
+	// Set twill.security.secret.disk.name to be consistent with securitySecret if not overwritten.
+	if _, ok := spec.Config[confTwillSecuritySecretDiskName]; !ok {
+		spec.Config[confTwillSecuritySecretDiskName] = spec.SecuritySecret
+	}
+
 	// Disable explore
 	spec.Config[confExploreEnabled] = "false"
 

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -47,12 +47,13 @@ const (
 	fieldNameCDAPExternalServiceSpec = "CDAPExternalServiceSpec"
 
 	// cconf and hconf
-	confExploreEnabled        = "explore.enabled"
-	confLocalDataDirKey       = "local.data.dir"
-	confLocalDataDirVal       = "/data"
-	confRouterServerAddress   = "router.server.address"
-	confRouterBindPort        = "router.bind.port"
-	confUserInterfaceBindPort = "dashboard.bind.port"
+	confExploreEnabled              = "explore.enabled"
+	confLocalDataDirKey             = "local.data.dir"
+	confLocalDataDirVal             = "/data"
+	confRouterServerAddress         = "router.server.address"
+	confRouterBindPort              = "router.bind.port"
+	confUserInterfaceBindPort       = "dashboard.bind.port"
+	confTwillSecuritySecretDiskName = "twill.security.secret.disk.name"
 
 	// default values
 	defaultImage             = "gcr.io/cdapio/cdap:latest"


### PR DESCRIPTION
This PR sets `twill.security.secret.disk.name` in CConf to be the same as `SecuritySecret` in the master CR which will help maintain consistency across the configurations.