### PR TITLE
[CDAP-18079 CDAP-18004] Add Support for Worker Secrets

### DIFF
--- a/controllers/cdapmaster_controller.go
+++ b/controllers/cdapmaster_controller.go
@@ -133,9 +133,20 @@ func ApplyDefaults(resource interface{}) {
 		spec.Config[confLocalDataDirKey] = confLocalDataDirVal
 	}
 
-	// Set twill.security.secret.disk.name to be consistent with securitySecret if not overwritten.
-	if _, ok := spec.Config[confTwillSecuritySecretDiskName]; !ok {
-		spec.Config[confTwillSecuritySecretDiskName] = spec.SecuritySecret
+	// Set security secret disk names to be consistent with securitySecret if not overwritten.
+	if _, ok := spec.Config[confTwillSecurityMasterSecretDiskName]; !ok && spec.SecuritySecret != "" {
+		spec.Config[confTwillSecurityMasterSecretDiskName] = spec.SecuritySecret
+	}
+	if _, ok := spec.Config[confTwillSecurityMasterSecretDiskPath]; !ok && spec.SecuritySecret != "" {
+		spec.Config[confTwillSecurityMasterSecretDiskPath] = defaultSecuritySecretPath
+	}
+	// This configuration makes the default securitySecret available to the workers by default.
+	// TODO: Add support for secure-by-default configurations.
+	if _, ok := spec.Config[confTwillSecurityWorkerSecretDiskName]; !ok && spec.SecuritySecret != "" {
+		spec.Config[confTwillSecurityWorkerSecretDiskName] = spec.SecuritySecret
+	}
+	if _, ok := spec.Config[confTwillSecurityWorkerSecretDiskPath]; !ok && spec.SecuritySecret != "" {
+		spec.Config[confTwillSecurityWorkerSecretDiskPath] = defaultSecuritySecretPath
 	}
 
 	// Disable explore

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -47,19 +47,23 @@ const (
 	fieldNameCDAPExternalServiceSpec = "CDAPExternalServiceSpec"
 
 	// cconf and hconf
-	confExploreEnabled              = "explore.enabled"
-	confLocalDataDirKey             = "local.data.dir"
-	confLocalDataDirVal             = "/data"
-	confRouterServerAddress         = "router.server.address"
-	confRouterBindPort              = "router.bind.port"
-	confUserInterfaceBindPort       = "dashboard.bind.port"
-	confTwillSecuritySecretDiskName = "twill.security.secret.disk.name"
+	confExploreEnabled                    = "explore.enabled"
+	confLocalDataDirKey                   = "local.data.dir"
+	confLocalDataDirVal                   = "/data"
+	confRouterServerAddress               = "router.server.address"
+	confRouterBindPort                    = "router.bind.port"
+	confUserInterfaceBindPort             = "dashboard.bind.port"
+	confTwillSecurityMasterSecretDiskName = "twill.security.master.secret.disk.name"
+	confTwillSecurityMasterSecretDiskPath = "twill.security.master.secret.disk.path"
+	confTwillSecurityWorkerSecretDiskName = "twill.security.worker.secret.disk.name"
+	confTwillSecurityWorkerSecretDiskPath = "twill.security.worker.secret.disk.path"
 
 	// default values
-	defaultImage             = "gcr.io/cdapio/cdap:latest"
-	defaultRouterPort        = 11015
-	defaultUserInterfacePort = 11011
-	defaultStorageSize       = "200Gi"
+	defaultImage              = "gcr.io/cdapio/cdap:latest"
+	defaultRouterPort         = 11015
+	defaultUserInterfacePort  = 11011
+	defaultStorageSize        = "200Gi"
+	defaultSecuritySecretPath = "/etc/cdap/security"
 
 	// kubernetes labels
 	labelInstanceKey        = "cdap.instance"

--- a/controllers/spec.go
+++ b/controllers/spec.go
@@ -131,6 +131,7 @@ type BaseSpec struct {
 	RuntimeClassName   string                    `json:"runtimeClassName,omitempty"`
 	PriorityClassName  string                    `json:"priorityClassName,omitempty"`
 	SecuritySecret     string                    `json:"securitySecret,omitempty"`
+	SecuritySecretPath string                    `json:"securitySecretPath,omitempty"`
 	CConf              string                    `json:"cdapConf,omitempty"`
 	HConf              string                    `json:"hadoopConf,omitempty"`
 	SysAppConf         string                    `json:"sysAppConf,omitempty"`
@@ -149,6 +150,7 @@ func newBaseSpec(master *v1alpha1.CDAPMaster, name string, labels map[string]str
 	s.RuntimeClassName = ""
 	s.PriorityClassName = ""
 	s.SecuritySecret = master.Spec.SecuritySecret
+	s.SecuritySecretPath = defaultSecuritySecretPath
 	s.CConf = cconf
 	s.HConf = hconf
 	s.SysAppConf = sysappconf

--- a/templates/cdap-deployment.yaml
+++ b/templates/cdap-deployment.yaml
@@ -121,7 +121,7 @@ spec:
               readOnly: true
             {{if $.Base.SecuritySecret}}
             - name: cdap-security
-              mountPath: /etc/cdap/security
+              mountPath: {{$.Base.SecuritySecretPath}}
               readOnly: true
             {{end}}
             {{range $k,$v := $.Base.ConfigMapVolumes}}

--- a/templates/cdap-sts.yaml
+++ b/templates/cdap-sts.yaml
@@ -99,7 +99,7 @@ spec:
               mountPath: {{.DataDir}}
             {{if $.Base.SecuritySecret}}
             - name: cdap-security
-              mountPath: /etc/cdap/security
+              mountPath: {{$.Base.SecuritySecretPath}}
               readOnly: true
             {{end}}
       {{end}}


### PR DESCRIPTION
Sets CConfiguration options for mounting secrets in worker pods including preview runner pods and task worker pods. Dependent on https://github.com/cdapio/cdap/pull/13485