### PR TITLE
Added ability to mount external PVCs to cdap deployments and statefulsets

### DIFF
--- a/api/v1alpha1/cdapmaster_types.go
+++ b/api/v1alpha1/cdapmaster_types.go
@@ -54,6 +54,10 @@ type CDAPMasterSpec struct {
 	// Key is the secret object name. Value is the mount path.
 	// This adds Secret data to the directory specified by the volume mount path.
 	SecretVolumes map[string]string `json:"secretVolumes,omitempty"`
+	// PVCVolumes defines a map from Persistent Volume Claim names to volume mount path.
+	// Key is the PVC object name. Value is the mount path.
+	// This mounts PVC to the directory specified by the volume mount path.
+	PVCVolumes map[string]string `json:"pvcVolumes,omitempty"`
 	// SystemAppConfigs specifies configs used by CDAP to run system apps
 	// dynamically. Each entry is of format <filename, json app config> which will
 	// create a separate system config file with entry value as file content.
@@ -117,6 +121,10 @@ type CDAPServiceSpec struct {
 	// Key is the secret object name. Value is the mount path.
 	// This adds Secret data to the directory specified by the volume mount path.
 	SecretVolumes map[string]string `json:"secretVolumes,omitempty"`
+	// PVCVolumes defines a map from Persistent Volume Claim names to volume mount path.
+	// Key is the PVC object name. Value is the mount path.
+	// This mounts PVC to the directory specified by the volume mount path.
+	PVCVolumes map[string]string `json:"pvcVolumes,omitempty"`
 	// SecurityContext overrides the security context for the service pods.
 	SecurityContext *SecurityContext `json:"securityContext,omitempty"`
 }

--- a/config/crd/bases/cdap.cdap.io_cdapmasters.yaml
+++ b/config/crd/bases/cdap.cdap.io_cdapmasters.yaml
@@ -199,6 +199,14 @@ spec:
                     is the mount path. This adds Secret data to the directory specified
                     by the volume mount path.
                   type: object
+                pvcVolumes:
+                  additionalProperties:
+                    type: string
+                  description: PVCVolumes defines a map from Persistent Volume Claim
+                    names to volume mount path. Key is the PVC object name. Value is the
+                    mount path. This mounts PVC to the directory specified by the volume
+                    mount path.
+                  type: object
                 securityContext:
                   description: SecurityContext overrides the security context for
                     the service pods.
@@ -420,6 +428,14 @@ spec:
                     mount path for this service Key is the secret object name. Value
                     is the mount path. This adds Secret data to the directory specified
                     by the volume mount path.
+                  type: object
+                pvcVolumes:
+                  additionalProperties:
+                    type: string
+                  description: PVCVolumes defines a map from Persistent Volume Claim
+                    names to volume mount path. Key is the PVC object name. Value is the
+                    mount path. This mounts PVC to the directory specified by the volume
+                    mount path.
                   type: object
                 securityContext:
                   description: SecurityContext overrides the security context for
@@ -656,6 +672,14 @@ spec:
                     is the mount path. This adds Secret data to the directory specified
                     by the volume mount path.
                   type: object
+                pvcVolumes:
+                  additionalProperties:
+                    type: string
+                  description: PVCVolumes defines a map from Persistent Volume Claim
+                    names to volume mount path. Key is the PVC object name. Value is the
+                    mount path. This mounts PVC to the directory specified by the volume
+                    mount path.
+                  type: object
                 securityContext:
                   description: SecurityContext overrides the security context for
                     the service pods.
@@ -869,6 +893,14 @@ spec:
                     mount path for this service Key is the secret object name. Value
                     is the mount path. This adds Secret data to the directory specified
                     by the volume mount path.
+                  type: object
+                pvcVolumes:
+                  additionalProperties:
+                    type: string
+                  description: PVCVolumes defines a map from Persistent Volume Claim
+                    names to volume mount path. Key is the PVC object name. Value is the
+                    mount path. This mounts PVC to the directory specified by the volume
+                    mount path.
                   type: object
                 securityContext:
                   description: SecurityContext overrides the security context for
@@ -1088,6 +1120,14 @@ spec:
                     is the mount path. This adds Secret data to the directory specified
                     by the volume mount path.
                   type: object
+                pvcVolumes:
+                  additionalProperties:
+                    type: string
+                  description: PVCVolumes defines a map from Persistent Volume Claim
+                    names to volume mount path. Key is the PVC object name. Value is the
+                    mount path. This mounts PVC to the directory specified by the volume
+                    mount path.
+                  type: object
                 securityContext:
                   description: SecurityContext overrides the security context for
                     the service pods.
@@ -1293,6 +1333,14 @@ spec:
                     mount path for this service Key is the secret object name. Value
                     is the mount path. This adds Secret data to the directory specified
                     by the volume mount path.
+                  type: object
+                pvcVolumes:
+                  additionalProperties:
+                    type: string
+                  description: PVCVolumes defines a map from Persistent Volume Claim
+                    names to volume mount path. Key is the PVC object name. Value is the
+                    mount path. This mounts PVC to the directory specified by the volume
+                    mount path.
                   type: object
                 securityContext:
                   description: SecurityContext overrides the security context for
@@ -1507,6 +1555,14 @@ spec:
                     mount path for this service Key is the secret object name. Value
                     is the mount path. This adds Secret data to the directory specified
                     by the volume mount path.
+                  type: object
+                pvcVolumes:
+                  additionalProperties:
+                    type: string
+                  description: PVCVolumes defines a map from Persistent Volume Claim
+                    names to volume mount path. Key is the PVC object name. Value is the
+                    mount path. This mounts PVC to the directory specified by the volume
+                    mount path.
                   type: object
                 securityContext:
                   description: SecurityContext overrides the security context for
@@ -1726,6 +1782,14 @@ spec:
                     is the mount path. This adds Secret data to the directory specified
                     by the volume mount path.
                   type: object
+                pvcVolumes:
+                  additionalProperties:
+                    type: string
+                  description: PVCVolumes defines a map from Persistent Volume Claim
+                    names to volume mount path. Key is the PVC object name. Value is the
+                    mount path. This mounts PVC to the directory specified by the volume
+                    mount path.
+                  type: object
                 securityContext:
                   description: SecurityContext overrides the security context for
                     the service pods.
@@ -1944,6 +2008,14 @@ spec:
                     is the mount path. This adds Secret data to the directory specified
                     by the volume mount path.
                   type: object
+                pvcVolumes:
+                  additionalProperties:
+                    type: string
+                  description: PVCVolumes defines a map from Persistent Volume Claim
+                    names to volume mount path. Key is the PVC object name. Value is the
+                    mount path. This mounts PVC to the directory specified by the volume
+                    mount path.
+                  type: object
                 securityContext:
                   description: SecurityContext overrides the security context for
                     the service pods.
@@ -2006,6 +2078,14 @@ spec:
                 mount path. Key is the secret object name. Value is the mount path.
                 This adds Secret data to the directory specified by the volume mount
                 path.
+              type: object
+            pvcVolumes:
+              additionalProperties:
+                type: string
+              description: PVCVolumes defines a map from Persistent Volume Claim
+                names to volume mount path. Key is the PVC object name. Value is the
+                mount path. This mounts PVC to the directory specified by the volume
+                mount path.
               type: object
             securityContext:
               description: SecurityContext defines the security context for all pods
@@ -2225,6 +2305,14 @@ spec:
                     mount path for this service Key is the secret object name. Value
                     is the mount path. This adds Secret data to the directory specified
                     by the volume mount path.
+                  type: object
+                pvcVolumes:
+                  additionalProperties:
+                    type: string
+                  description: PVCVolumes defines a map from Persistent Volume Claim
+                    names to volume mount path. Key is the PVC object name. Value is the
+                    mount path. This mounts PVC to the directory specified by the volume
+                    mount path.
                   type: object
                 securityContext:
                   description: SecurityContext overrides the security context for

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -198,6 +198,9 @@ func buildStatefulSets(master *v1alpha1.CDAPMaster, name string, services Servic
 		if _, err := spec.addSecretVolumes(ss.SecretVolumes); err != nil {
 			return nil, err
 		}
+		if _, err := spec.addPVCVolumes(ss.PVCVolumes); err != nil {
+			return nil, err
+		}
 	}
 
 	// All services are optional services and are disabled in CR.
@@ -281,6 +284,9 @@ func buildDeployment(master *v1alpha1.CDAPMaster, name string, services ServiceG
 			return nil, err
 		}
 		if _, err := spec.addSecretVolumes(ss.SecretVolumes); err != nil {
+			return nil, err
+		}
+		if _, err := spec.addPVCVolumes(ss.PVCVolumes); err != nil {
 			return nil, err
 		}
 	}

--- a/controllers/spec.go
+++ b/controllers/spec.go
@@ -137,6 +137,7 @@ type BaseSpec struct {
 	SysAppConf         string                    `json:"sysAppConf,omitempty"`
 	ConfigMapVolumes   map[string]string         `json:"configMapVolumes,omitempty"`
 	SecretVolumes      map[string]string         `json:"secretVolumes,omitempty"`
+	PVCVolumes   	   map[string]string         `json:"pvcVolumes,omitempty"`
 	SecurityContext    *v1alpha1.SecurityContext `json:"securityContext,omitempty"`
 }
 
@@ -156,6 +157,7 @@ func newBaseSpec(master *v1alpha1.CDAPMaster, name string, labels map[string]str
 	s.SysAppConf = sysappconf
 	s.ConfigMapVolumes = cloneMap(master.Spec.ConfigMapVolumes)
 	s.SecretVolumes = cloneMap(master.Spec.SecretVolumes)
+	s.PVCVolumes = cloneMap(master.Spec.PVCVolumes)
 
 	return s
 }
@@ -200,6 +202,13 @@ func (s *BaseSpec) addConfigMapVolumes(volumes map[string]string) (*BaseSpec, er
 
 func (s *BaseSpec) addSecretVolumes(volumes map[string]string) (*BaseSpec, error) {
 	if err := addVolumes(s.SecretVolumes, volumes, "Secret"); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *BaseSpec) addPVCVolumes(volumes map[string]string) (*BaseSpec, error) {
+	if err := addVolumes(s.PVCVolumes, volumes, "Persistent Volume Claim"); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -306,6 +315,13 @@ func (s *DeploymentSpec) addSecretVolumes(volumes map[string]string) (*Deploymen
 	return s, nil
 }
 
+func (s *DeploymentSpec) addPVCVolumes(volumes map[string]string) (*DeploymentSpec, error) {
+	if _, err := s.Base.addPVCVolumes(volumes); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
 func (s *DeploymentSpec) setSecurityContext(securityContext *v1alpha1.SecurityContext) *DeploymentSpec {
 	s.Base.setSecurityContext(securityContext)
 	return s
@@ -392,6 +408,13 @@ func (s *StatefulSpec) addConfigMapVolumes(volumes map[string]string) (*Stateful
 
 func (s *StatefulSpec) addSecretVolumes(volumes map[string]string) (*StatefulSpec, error) {
 	if _, err := s.Base.addSecretVolumes(volumes); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *StatefulSpec) addPVCVolumes(volumes map[string]string) (*StatefulSpec, error) {
+	if _, err := s.Base.addPVCVolumes(volumes); err != nil {
 		return nil, err
 	}
 	return s, nil

--- a/controllers/testdata/appfabric.json
+++ b/controllers/testdata/appfabric.json
@@ -136,6 +136,14 @@
               {
                 "mountPath": "/my/secret/1",
                 "name": "cdap-se-vol-my-secret-1"
+              },
+              {
+                "mountPath": "/my/pvc/0",
+                "name": "cdap-vol-my-pvc-0"
+              },
+              {
+                "mountPath": "/my/pvc/1",
+                "name": "cdap-vol-my-pvc-1"
               }
             ]
           }
@@ -189,6 +197,14 @@
               {
                 "mountPath": "/my/secret/1",
                 "name": "cdap-se-vol-my-secret-1"
+              },
+              {
+                "mountPath": "/my/pvc/0",
+                "name": "cdap-vol-my-pvc-0"
+              },
+              {
+                "mountPath": "/my/pvc/1",
+                "name": "cdap-vol-my-pvc-1"
               }
             ]
           }
@@ -282,6 +298,18 @@
             "secret": {
               "defaultMode": 420,
               "secretName": "my-secret-1"
+            }
+          },
+          {
+            "name": "cdap-vol-my-pvc-0",
+            "persistentVolumeClaim": {
+              "claimName": "my-pvc-0"
+            }
+          },
+          {
+            "name": "cdap-vol-my-pvc-1",
+            "persistentVolumeClaim": {
+              "claimName": "my-pvc-1"
             }
           }
         ]

--- a/controllers/testdata/authentication.json
+++ b/controllers/testdata/authentication.json
@@ -135,6 +135,10 @@
               {
                 "mountPath": "/my/secret/key",
                 "name": "cdap-se-vol-secret-key"
+              },
+              {
+                "mountPath": "/my/pvc/0",
+                "name": "cdap-vol-my-pvc-0"
               }
             ]
           }
@@ -232,6 +236,12 @@
             "name": "cdap-se-vol-secret-key",
             "secret": {
               "secretName": "secret-key"
+            }
+          },
+          {
+            "name": "cdap-vol-my-pvc-0",
+            "persistentVolumeClaim": {
+              "claimName": "my-pvc-0"
             }
           }
         ]

--- a/controllers/testdata/cdap_master_cr.json
+++ b/controllers/testdata/cdap_master_cr.json
@@ -42,6 +42,9 @@
         "runAsGroup": 3000,
         "fsGroup": 4000,
         "runAsNonRoot": false
+      },
+      "pvcVolumes": {
+        "my-pvc-1": "/my/pvc/1"
       }
     },
     "authentication": {
@@ -80,6 +83,9 @@
     },
     "secretVolumes": {
       "my-secret-1": "/my/secret/1"
+    },
+    "pvcVolumes": {
+      "my-pvc-0": "/my/pvc/0"
     },
     "image": "gcr.io/cloud-data-fusion-images/cloud-data-fusion:6.1.0.5",
     "locationURI": "hdfs://hadoop:9000",

--- a/controllers/testdata/logs.json
+++ b/controllers/testdata/logs.json
@@ -125,6 +125,10 @@
               {
                 "mountPath": "/my/secret/1",
                 "name": "cdap-se-vol-my-secret-1"
+              },
+              {
+                "mountPath": "/my/pvc/0",
+                "name": "cdap-vol-my-pvc-0"
               }
             ]
           }
@@ -182,6 +186,10 @@
               {
                 "mountPath": "/my/secret/1",
                 "name": "cdap-se-vol-my-secret-1"
+              },
+              {
+                "mountPath": "/my/pvc/0",
+                "name": "cdap-vol-my-pvc-0"
               }
             ]
           }
@@ -274,6 +282,12 @@
             "secret": {
               "defaultMode": 420,
               "secretName": "my-secret-1"
+            }
+          },
+          {
+            "name": "cdap-vol-my-pvc-0",
+            "persistentVolumeClaim": {
+              "claimName": "my-pvc-0"
             }
           }
         ]

--- a/controllers/testdata/messaging.json
+++ b/controllers/testdata/messaging.json
@@ -125,6 +125,10 @@
               {
                 "mountPath": "/my/secret/1",
                 "name": "cdap-se-vol-my-secret-1"
+              },
+              {
+                "mountPath": "/my/pvc/0",
+                "name": "cdap-vol-my-pvc-0"
               }
             ]
           }
@@ -182,6 +186,10 @@
               {
                 "mountPath": "/my/secret/1",
                 "name": "cdap-se-vol-my-secret-1"
+              },
+              {
+                "mountPath": "/my/pvc/0",
+                "name": "cdap-vol-my-pvc-0"
               }
             ]
           }
@@ -274,6 +282,12 @@
             "secret": {
               "defaultMode": 420,
               "secretName": "my-secret-1"
+            }
+          },
+          {
+            "name": "cdap-vol-my-pvc-0",
+            "persistentVolumeClaim": {
+              "claimName": "my-pvc-0"
             }
           }
         ]

--- a/controllers/testdata/metadata.json
+++ b/controllers/testdata/metadata.json
@@ -131,6 +131,10 @@
               {
                 "mountPath": "/my/secret/1",
                 "name": "cdap-se-vol-my-secret-1"
+              },
+              {
+                "mountPath": "/my/pvc/0",
+                "name": "cdap-vol-my-pvc-0"
               }
             ]
           }
@@ -222,6 +226,12 @@
             "secret": {
               "defaultMode": 420,
               "secretName": "my-secret-1"
+            }
+          },
+          {
+            "name": "cdap-vol-my-pvc-0",
+            "persistentVolumeClaim": {
+              "claimName": "my-pvc-0"
             }
           }
         ]

--- a/controllers/testdata/metrics.json
+++ b/controllers/testdata/metrics.json
@@ -125,6 +125,10 @@
               {
                 "mountPath": "/my/secret/1",
                 "name": "cdap-se-vol-my-secret-1"
+              },
+              {
+                "mountPath": "/my/pvc/0",
+                "name": "cdap-vol-my-pvc-0"
               }
             ]
           }
@@ -182,6 +186,10 @@
               {
                 "mountPath": "/my/secret/1",
                 "name": "cdap-se-vol-my-secret-1"
+              },
+              {
+                "mountPath": "/my/pvc/0",
+                "name": "cdap-vol-my-pvc-0"
               }
             ]
           }
@@ -274,6 +282,12 @@
             "secret": {
               "defaultMode": 420,
               "secretName": "my-secret-1"
+            }
+          },
+          {
+            "name": "cdap-vol-my-pvc-0",
+            "persistentVolumeClaim": {
+              "claimName": "my-pvc-0"
             }
           }
         ]

--- a/controllers/testdata/preview.json
+++ b/controllers/testdata/preview.json
@@ -125,6 +125,10 @@
               {
                 "mountPath": "/my/secret/1",
                 "name": "cdap-se-vol-my-secret-1"
+              },
+              {
+                "mountPath": "/my/pvc/0",
+                "name": "cdap-vol-my-pvc-0"
               }
             ]
           }
@@ -182,6 +186,10 @@
               {
                 "mountPath": "/my/secret/1",
                 "name": "cdap-se-vol-my-secret-1"
+              },
+              {
+                "mountPath": "/my/pvc/0",
+                "name": "cdap-vol-my-pvc-0"
               }
             ]
           }
@@ -272,6 +280,12 @@
             "secret": {
               "defaultMode": 420,
               "secretName": "my-secret-1"
+            }
+          },
+          {
+            "name": "cdap-vol-my-pvc-0",
+            "persistentVolumeClaim": {
+              "claimName": "my-pvc-0"
             }
           }
         ]

--- a/controllers/testdata/router.json
+++ b/controllers/testdata/router.json
@@ -134,6 +134,10 @@
               {
                 "mountPath": "/my/secret/key",
                 "name": "cdap-se-vol-secret-key"
+              },
+              {
+                "mountPath": "/my/pvc/0",
+                "name": "cdap-vol-my-pvc-0"
               }
             ]
           }
@@ -231,6 +235,12 @@
             "name": "cdap-se-vol-secret-key",
             "secret": {
               "secretName": "secret-key"
+            }
+          },
+          {
+            "name": "cdap-vol-my-pvc-0",
+            "persistentVolumeClaim": {
+              "claimName": "my-pvc-0"
             }
           }
         ]

--- a/controllers/testdata/runtime.json
+++ b/controllers/testdata/runtime.json
@@ -136,6 +136,10 @@
               {
                 "mountPath": "/my/secret/1",
                 "name": "cdap-se-vol-my-secret-1"
+              },
+              {
+                "mountPath": "/my/pvc/0",
+                "name": "cdap-vol-my-pvc-0"
               }
             ]
           }
@@ -189,6 +193,10 @@
               {
                 "mountPath": "/my/secret/1",
                 "name": "cdap-se-vol-my-secret-1"
+              },
+              {
+                "mountPath": "/my/pvc/0",
+                "name": "cdap-vol-my-pvc-0"
               }
             ]
           }
@@ -280,6 +288,12 @@
             "secret": {
               "defaultMode": 420,
               "secretName": "my-secret-1"
+            }
+          },
+          {
+            "name": "cdap-vol-my-pvc-0",
+            "persistentVolumeClaim": {
+              "claimName": "my-pvc-0"
             }
           }
         ]

--- a/controllers/testdata/userinterface.json
+++ b/controllers/testdata/userinterface.json
@@ -137,6 +137,10 @@
               {
                 "mountPath": "/my/secret/1",
                 "name": "cdap-se-vol-my-secret-1"
+              },
+              {
+                "mountPath": "/my/pvc/0",
+                "name": "cdap-vol-my-pvc-0"
               }
             ],
             "workingDir": "/opt/cdap/ui"
@@ -229,6 +233,12 @@
             "secret": {
               "defaultMode": 420,
               "secretName": "my-secret-1"
+            }
+          },
+          {
+            "name": "cdap-vol-my-pvc-0",
+            "persistentVolumeClaim": {
+              "claimName": "my-pvc-0"
             }
           }
         ]

--- a/templates/cdap-deployment.yaml
+++ b/templates/cdap-deployment.yaml
@@ -132,6 +132,10 @@ spec:
             - name: cdap-se-vol-{{$k}}
               mountPath: {{$v}}
             {{end}}
+            {{range $k,$v := $.Base.PVCVolumes}}
+            - name: cdap-vol-{{$k}}
+              mountPath: {{$v}}
+            {{end}}
       {{end}}
       volumes:
         - name: podinfo
@@ -169,4 +173,9 @@ spec:
         - name: cdap-se-vol-{{$k}}
           secret:
             secretName: {{$k}}
+        {{end}}
+        {{range $k,$v := $.Base.PVCVolumes}}
+        - name: cdap-vol-{{$k}}
+          persistentVolumeClaim:
+            claimName: {{$k}}
         {{end}}

--- a/templates/cdap-sts.yaml
+++ b/templates/cdap-sts.yaml
@@ -172,6 +172,10 @@ spec:
             - name: cdap-se-vol-{{$k}}
               mountPath: {{$v}}
             {{end}}
+            {{range $k,$v := $.Base.PVCVolumes}}
+            - name: cdap-vol-{{$k}}
+              mountPath: {{$v}}
+            {{end}}
       {{end}}
       volumes:
         - name: podinfo
@@ -209,6 +213,11 @@ spec:
         - name: cdap-se-vol-{{$k}}
           secret:
             secretName: {{$k}}
+        {{end}}
+        {{range $k,$v := $.Base.PVCVolumes}}
+        - name: cdap-vol-{{$k}}
+          persistentVolumeClaim:
+            claimName: {{$k}}
         {{end}}
   volumeClaimTemplates:
   - metadata:


### PR DESCRIPTION
There is a requirement to mount read-write storage for saving securestore file and custom jar for authorization. We are not able to use secretVolume and configMap because they are read-only and limited by maximal size of content.

So was decided to add property for mounting existing k8s PVCs to CDAP statefulsets and deployments.This feature has a similar design to secretVolume and configMap mounting features.

Example of usage:
```
spec:
  ...
  config:
    security.authorization.extension.jar.path: "/etc/securestorage/cdap-authorization-ldap-role.jar"
   ...
  pvcVolumes:
    task-pv-claim: "/etc/securestorage"
```
In this case pvc with name `task-pv-claim` will be mounted to `/etc/securestorage` for all CDAP pods.


Testing:

cdap-operator was built:
`sudo docker build . -t cdap-operator-pvc:0.0.1`
and used to setup file-based securestore and custom ldap based authorization on CDAP v6.5.0.

Unit testing:
```
go test ./... -coverprofile cover.out
?   	cdap.io/cdap-operator	[no test files]
?   	cdap.io/cdap-operator/api/v1alpha1	[no test files]
ok  	cdap.io/cdap-operator/controllers	8.509s	coverage: 61.5% of statements
?   	cdap.io/cdap-operator/controllers/cdapmaster	[no test files]
```