### PR TITLE
[CDAP-20574] Update go version in builder Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.19 as builder
 
 # Copy everything in the go src
 WORKDIR /go/src/cdap.io/cdap-operator


### PR DESCRIPTION
# [CDAP-20574](https://cdap.atlassian.net/browse/CDAP-20574)

This is required to resolve security vulnerabilities. Develop is already using 1.19 due to https://github.com/cdapio/cdap-operator/pull/94

## Tested
Built docker image and deployed it to a k8s cluster. The operator correctly updated appfarbric spec on change resource requests in the CDAP CR.

[CDAP-20574]: https://cdap.atlassian.net/browse/CDAP-20574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ