### PR TITLE
[CDAP-20714] Support creation of Router as a LoadBalancer service

### DIFF
--- a/api/v1alpha1/cdapmaster_types.go
+++ b/api/v1alpha1/cdapmaster_types.go
@@ -184,8 +184,12 @@ type CDAPExternalServiceSpec struct {
 	CDAPScalableServiceSpec `json:",inline"`
 	// ServiceType is the service type in kubernetes, default is NodePort.
 	ServiceType *string `json:"serviceType,omitempty"`
+	// LoadBalancerIP is the static IP address reserved for the service's load balancer.
+	LoadBalancerIP *string `json:"loadBalancerIP,omitempty"`
 	// ServicePort is the port number for the service.
 	ServicePort *int32 `json:"servicePort,omitempty"`
+	// Annotations are the metadata annotations for the kubernetes service. They can be used to configure cloud provider specific behavior for LoadBalancer services.
+	Annotations map[string]string `json:"Annotations,omitempty"`
 }
 
 // CDAPStatefulServiceSpec defines the base specification for stateful master services.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -83,10 +83,22 @@ func (in *CDAPExternalServiceSpec) DeepCopyInto(out *CDAPExternalServiceSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.LoadBalancerIP != nil {
+		in, out := &in.LoadBalancerIP, &out.LoadBalancerIP
+		*out = new(string)
+		**out = **in
+	}
 	if in.ServicePort != nil {
 		in, out := &in.ServicePort, &out.ServicePort
 		*out = new(int32)
 		**out = **in
+	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 }
 

--- a/config/crd/bases/cdap.cdap.io_cdapmasters.yaml
+++ b/config/crd/bases/cdap.cdap.io_cdapmasters.yaml
@@ -24801,6 +24801,13 @@ spec:
               router:
                 description: Router is specification for the CDAP router service.
                 properties:
+                  Annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations are the metadata annotations for the
+                      kubernetes service. They can be used to configure cloud provider
+                      specific behavior for LoadBalancer services.
+                    type: object
                   additionalVolumeMounts:
                     description: AdditionalVolumeMounts defines a list of additional
                       volume mounts for the service. For information on supported
@@ -27576,6 +27583,10 @@ spec:
                             type: object
                         type: object
                     type: object
+                  loadBalancerIP:
+                    description: LoadBalancerIP is the static IP address reserved
+                      for the service's load balancer.
+                    type: string
                   metadata:
                     description: Metadata for the service.
                     type: object
@@ -39317,6 +39328,13 @@ spec:
               userInterface:
                 description: UserInterface is specification for the CDAP UI service.
                 properties:
+                  Annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations are the metadata annotations for the
+                      kubernetes service. They can be used to configure cloud provider
+                      specific behavior for LoadBalancer services.
+                    type: object
                   additionalVolumeMounts:
                     description: AdditionalVolumeMounts defines a list of additional
                       volume mounts for the service. For information on supported
@@ -42092,6 +42110,10 @@ spec:
                             type: object
                         type: object
                     type: object
+                  loadBalancerIP:
+                    description: LoadBalancerIP is the static IP address reserved
+                      for the service's load balancer.
+                    type: string
                   metadata:
                     description: Metadata for the service.
                     type: object

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -554,7 +554,7 @@ func buildNetworkService(master *v1alpha1.CDAPMaster, name NetworkServiceName, t
 		return nil, err
 	}
 	objName := getObjName(master, name)
-	return newNetworkServiceSpec(objName, labels, s.ServiceType, s.ServicePort, master).
+	return newNetworkServiceSpec(objName, labels, s.Annotations, s.ServiceType, s.LoadBalancerIP, s.ServicePort, master).
 		addSelector(labelContainerKeyPrefix+target, master.Name), nil
 }
 

--- a/controllers/spec.go
+++ b/controllers/spec.go
@@ -480,25 +480,26 @@ func (s *StatefulSpec) setSecurityContext(securityContext *v1alpha1.SecurityCont
 }
 
 type NetworkServiceSpec struct {
-	Name        string             `json:"name,omitempty"`
-	Namespace   string             `json:"namespace,omitempty"`
-	Annotations *map[string]string `json:"annotations,omitempty"`
-	Labels      map[string]string  `json:"labels,omitempty"`
-	Selectors   map[string]string  `json:"selectors,omitempty"`
-	ServiceType *string            `json:"serviceType,omitempty"`
-	ServicePort *int32             `json:"servicePort,omitempty"`
+	Name           string            `json:"name,omitempty"`
+	Namespace      string            `json:"namespace,omitempty"`
+	Annotations    map[string]string `json:"annotations,omitempty"`
+	Labels         map[string]string `json:"labels,omitempty"`
+	Selectors      map[string]string `json:"selectors,omitempty"`
+	ServiceType    *string           `json:"serviceType,omitempty"`
+	ServicePort    *int32            `json:"servicePort,omitempty"`
+	LoadBalancerIP *string           `json:"loadBalancerIP,omitempty"`
 }
 
-func newNetworkServiceSpec(name string, labels map[string]string, serviceType *string, port *int32, master *v1alpha1.CDAPMaster) *NetworkServiceSpec {
+func newNetworkServiceSpec(name string, labels, annotations map[string]string, serviceType, loadBalancerIP *string, port *int32, master *v1alpha1.CDAPMaster) *NetworkServiceSpec {
 	s := new(NetworkServiceSpec)
 	s.Name = name
 	s.Namespace = master.Namespace
-	// TODO: are annotations needed?
-	s.Annotations = nil
+	s.Annotations = mergeMaps(annotations, map[string]string{})
 	s.Labels = mergeMaps(labels, map[string]string{})
 	s.Selectors = mergeMaps(labels, map[string]string{})
 	s.ServiceType = serviceType
 	s.ServicePort = port
+	s.LoadBalancerIP = loadBalancerIP
 	return s
 }
 func (s *NetworkServiceSpec) addLabel(key, val string) *NetworkServiceSpec {

--- a/controllers/testdata/cdap_master_cr.json
+++ b/controllers/testdata/cdap_master_cr.json
@@ -251,6 +251,11 @@
       "replicas": 2
     },
     "router": {
+      "Annotations": {
+        "networking.gke.io/load-balancer-type":"Internal"
+      },
+      "loadBalancerIP": "172.25.80.9",
+      "serviceType": "LoadBalancer",
       "affinity": {
         "podAntiAffinity": {
           "preferredDuringSchedulingIgnoredDuringExecution": [

--- a/controllers/testdata/router_service.json
+++ b/controllers/testdata/router_service.json
@@ -2,6 +2,9 @@
   "apiVersion": "v1",
   "kind": "Service",
   "metadata": {
+    "annotations": {
+        "networking.gke.io/load-balancer-type": "Internal"
+    },
     "creationTimestamp": null,
     "labels": {
       "cdap.instance": "test",
@@ -30,6 +33,7 @@
   "spec": {
     "clusterIP": "10.47.252.214",
     "externalTrafficPolicy": "Cluster",
+    "loadBalancerIP": "172.25.80.9",
     "ports": [
       {
         "nodePort": 32588,
@@ -47,7 +51,7 @@
       "using": "controllers.ServiceHandler"
     },
     "sessionAffinity": "None",
-    "type": "NodePort"
+    "type": "LoadBalancer"
   },
   "status": {
     "loadBalancer": {}

--- a/templates/cdap-service.yaml
+++ b/templates/cdap-service.yaml
@@ -28,6 +28,9 @@ metadata:
     {{end}}
 {{end}}
 spec:
+{{if .LoadBalancerIP}}
+  loadBalancerIP: {{.LoadBalancerIP}}
+{{end}}
 {{if .ServiceType}}
   type: {{.ServiceType}}
 {{else}}
@@ -38,7 +41,6 @@ spec:
     {{$k}}: "{{$v}}"
     {{end}}
   ports:
-
   - protocol: TCP
     port: {{.ServicePort}}
     targetPort: {{.ServicePort}}


### PR DESCRIPTION
## [CDAP-20714](https://cdap.atlassian.net/browse/CDAP-20714)

List of fields added:
* LoadBalancerIP: Optional static IP to be used for load balancer services.
* ServiceAnnotations: Used to configure Cloud Provider specific properties for load balancers such as type of load balancer in GCP. The field name `Annotations` is already present in the ObjectMeta struct and is used to set the metadata for the k8s deployment, hence the name `ServiceAnnotations` is used.

Manually tested the operator by making `Router` a load balancer service in a GKE cluster with a reserved static IP.

[CDAP-20714]: https://cdap.atlassian.net/browse/CDAP-20714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ