### PR TITLE
[CDAP-20996] Reduce the length of pre-upgrade and post-upgrade job names so that it does not exceed 63 char limit

### DIFF
--- a/api/v1alpha1/cdapmaster_types.go
+++ b/api/v1alpha1/cdapmaster_types.go
@@ -27,10 +27,10 @@ import (
 // CDAPMasterSpec defines the desired state of CDAPMaster
 //
 // Important notes:
-// * The field name of each service MUST match the constant values of ServiceName in constants.go as reflection
-//   is used to find field value.
-// * For services that are optional (i.e. may or may not be required for CDAP to be operational), their service
-//   specification fields are pointers. By default, these optional services are disabled. Set to non-nil to enable them.
+//   - The field name of each service MUST match the constant values of ServiceName in constants.go as reflection
+//     is used to find field value.
+//   - For services that are optional (i.e. may or may not be required for CDAP to be operational), their service
+//     specification fields are pointers. By default, these optional services are disabled. Set to non-nil to enable them.
 type CDAPMasterSpec struct {
 	// Image is the docker image name for the CDAP backend.
 	Image string `json:"image,omitempty"`

--- a/controllers/testdata/post_upgrade_job.json
+++ b/controllers/testdata/post_upgrade_job.json
@@ -10,7 +10,7 @@
       "custom-resource-namespace": "default",
       "using": "controllers.VersionUpdateHandler"
     },
-    "name": "cdap-test-post-upgrade-job-1581238669880",
+    "name": "cdap-test-post-upgrade-job-1581238669",
     "namespace": "default",
     "ownerReferences": [
       {
@@ -30,7 +30,7 @@
       }
     ],
     "resourceVersion": "1876398",
-    "selfLink": "/apis/batch/v1/namespaces/default/jobs/cdap-test-post-upgrade-job-1581233225335",
+    "selfLink": "/apis/batch/v1/namespaces/default/jobs/cdap-test-post-upgrade-job-1581233225",
     "uid": "a0afd92d-4b0d-11ea-8611-42010a800022"
   },
   "spec": {
@@ -51,7 +51,7 @@
           "custom-resource": "v1alpha1.CDAPMaster",
           "custom-resource-name": "test",
           "custom-resource-namespace": "default",
-          "job-name": "cdap-test-post-upgrade-job-1581233225335",
+          "job-name": "cdap-test-post-upgrade-job-1581233225",
           "using": "controllers.VersionUpdateHandler"
         }
       },

--- a/controllers/testdata/pre_upgrade_job.json
+++ b/controllers/testdata/pre_upgrade_job.json
@@ -10,7 +10,7 @@
       "custom-resource-namespace": "default",
       "using": "controllers.VersionUpdateHandler"
     },
-    "name": "cdap-test-pre-upgrade-job-1581238669880",
+    "name": "cdap-test-pre-upgrade-job-1581238669",
     "namespace": "default",
     "ownerReferences": [
       {
@@ -30,7 +30,7 @@
       }
     ],
     "resourceVersion": "1896807",
-    "selfLink": "/apis/batch/v1/namespaces/default/jobs/cdap-test-pre-upgrade-job-1581238669880",
+    "selfLink": "/apis/batch/v1/namespaces/default/jobs/cdap-test-pre-upgrade-job-1581238669",
     "uid": "401828eb-4b1a-11ea-8611-42010a800022"
   },
   "spec": {
@@ -51,7 +51,7 @@
           "custom-resource": "v1alpha1.CDAPMaster",
           "custom-resource-name": "test",
           "custom-resource-namespace": "default",
-          "job-name": "cdap-test-pre-upgrade-job-1581238669880",
+          "job-name": "cdap-test-pre-upgrade-job-1581238669",
           "using": "controllers.VersionUpdateHandler"
         }
       },

--- a/controllers/version_update.go
+++ b/controllers/version_update.go
@@ -242,19 +242,22 @@ func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, ob
 
 // For upgrade:
 // - When succeeded:
-//   * PreUpgradeSucceeded, PostUpgradeSucceeded and UpgradeSucceeded are set
-//   * Status.ImageToUse (new image) == Spec.Image (new image)
+//   - PreUpgradeSucceeded, PostUpgradeSucceeded and UpgradeSucceeded are set
+//   - Status.ImageToUse (new image) == Spec.Image (new image)
+//
 // - When failed, two cases
-//   1) Preupgrade failed
-//      * PreUpgradeFailed and UpgradeFailed are set
-//      * Status.ImageToUse (new image) != Spec.Image (current image)
-//   2) Postupgrade failed
-//      * PostUpgradeFailed and UpgradeFailed are set
-//      * Status.ImageToUse (new image) == Spec.Image (new image)
+//  1. Preupgrade failed
+//     * PreUpgradeFailed and UpgradeFailed are set
+//     * Status.ImageToUse (new image) != Spec.Image (current image)
+//  2. Postupgrade failed
+//     * PostUpgradeFailed and UpgradeFailed are set
+//     * Status.ImageToUse (new image) == Spec.Image (new image)
+//
 // For downgrade:
 // - When succeeded:
-//   * DowngradeSucceeded is set
-//   * Status.ImageToUse (new image) == Spec.Image (new image)
+//   - DowngradeSucceeded is set
+//   - Status.ImageToUse (new image) == Spec.Image (new image)
+//
 // - When failed (currently not possible, as we just set the new version directly)
 type VersionUpdateStatus struct {
 	// common states
@@ -403,8 +406,8 @@ func parseImageString(imageString string) (*Version, error) {
 
 // compare two parsed versions
 // -1: left < right
-//  0: left = right
-//  1: left > right
+// 0: left = right
+// 1: left > right
 func compareVersion(l, r *Version) int {
 	if l.latest && r.latest {
 		return 0
@@ -500,12 +503,12 @@ func getCurrentTimeMs() int64 {
 
 // The returned name is just the suffix of actual k8s object name, as we prepend it with const string + CR name
 func getPreUpgradeJobName(startTimeMs int64) string {
-	return fmt.Sprintf("pre-upgrade-job-%d", startTimeMs)
+	return fmt.Sprintf("pre-upgrade-job-%d", startTimeMs / 1000)
 }
 
 // The returned name is just the suffix of actual k8s object name, as we prepend it with const string + CR name
 func getPostUpgradeJobName(startTimeMs int64) string {
-	return fmt.Sprintf("post-upgrade-job-%d", startTimeMs)
+	return fmt.Sprintf("post-upgrade-job-%d", startTimeMs / 1000)
 }
 
 // Return pre-upgrade job spec


### PR DESCRIPTION
Fixes the issue:
```
024/04/14 08:58:45 genericreconciler.go:255: *v1alpha1.CDAPMaster/default/xxxxxxxxxx(cmpnt:*controllers.VersionUpdateHandler)  Observed Resources:
2024/04/14 08:58:45 genericreconciler.go:260: *v1alpha1.CDAPMaster/default/xxxxxxxxxx(cmpnt:*controllers.VersionUpdateHandler)  Reconciling Resources:
E0414 08:58:45.283615       1 genericreconciler.go:53] Failed: [*v1alpha1.CDAPMaster/default/xxxxxxxxxx(cmpnt:*controllers.VersionUpdateHandler)] Create. Job.batch "xxxxxxxxxx-pre-upgrade-job-1703116128501" is invalid: spec.template.labels: Invalid value: "cdap-xxxxxxxxxx-pre-upgrade-job-1703116128501": must be no more than 63 characters
2024/04/14 08:58:45 genericreconciler.go:357: *v1alpha1.CDAPMaster/default/xxxxxxxxxx(cmpnt:*controllers.VersionUpdateHandler)  } reconciling component
E0414 08:58:45.283658       1 genericreconciler.go:116] error reconciling *v1alpha1.CDAPMaster/default/xxxxxxxxxx. Job.batch "cdap-xxxxxxxxxx-pre-upgrade-job-1703116128501" 
is invalid: spec.template.labels: Invalid value: "cdap-xxxxxxxxxx-pre-upgrade-job-1703116128501": must be no more than 63 characters
```