### PR TITLE
Refactor upgrade logic to skip pre upgrade job in case of patch revisions

### DIFF
--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -68,7 +68,7 @@ const (
 	confTwillSecurityWorkerSecretDiskPath = "twill.security.worker.secret.disk.path"
 	confJMXServerPort                     = "jmx.metrics.collector.server.port"
 	confSecretMountDefaultMode            = "secret.mount.default.mode"
-	confSkipPreUpgradeFlag                = "cdap-operator.preupgrade-job.skip"
+	confSkipPreUpgrade                    = "cdap-operator.preupgrade-job.skip"
 
 	// default values
 	defaultImage                  = "gcr.io/cdapio/cdap:latest"

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -68,6 +68,7 @@ const (
 	confTwillSecurityWorkerSecretDiskPath = "twill.security.worker.secret.disk.path"
 	confJMXServerPort                     = "jmx.metrics.collector.server.port"
 	confSecretMountDefaultMode            = "secret.mount.default.mode"
+	confSkipPreUpgradeFlag                = "cdap-operator.preupgrade-job.skip"
 
 	// default values
 	defaultImage                  = "gcr.io/cdapio/cdap:latest"

--- a/controllers/version_update.go
+++ b/controllers/version_update.go
@@ -41,12 +41,12 @@ func handleVersionUpdate(master *v1alpha1.CDAPMaster, labels map[string]string, 
 		return nil, err
 	}
 	versionComparison := compareVersion(curVersion, newVersion)
-	isPatchRevision := versionComparison == -2
+	patchRevision := versionComparison == -4
 
 	// Let the current update complete if there is any
 	if isConditionTrue(master, updateStatus.Inprogress) {
 		log.Printf("Version update ingress. Continue... ")
-		return upgradeForBackend(master, labels, observed, isPatchRevision)
+		return upgradeForBackend(master, labels, observed, patchRevision)
 	}
 
 	if objs, versionUpdated, err := updateForUserInterface(master); err != nil {
@@ -62,7 +62,7 @@ func handleVersionUpdate(master *v1alpha1.CDAPMaster, labels map[string]string, 
 	}
 
 	switch versionComparison {
-	case -2, -1:
+	case -1, -2, -3, -4:
 		// Upgrade case
 
 		// Don't retry upgrade if it failed.
@@ -76,7 +76,7 @@ func handleVersionUpdate(master *v1alpha1.CDAPMaster, labels map[string]string, 
 		setCondition(master, updateStatus.Inprogress)
 		master.Status.UpgradeStartTimeMillis = getCurrentTimeMs()
 		log.Printf("Version update: start upgrading %s -> %s ", curVersion.rawString, newVersion.rawString)
-		return upgradeForBackend(master, labels, observed, isPatchRevision)
+		return upgradeForBackend(master, labels, observed, patchRevision)
 	case 0:
 		// Reset all condition so that failed upgraded/downgrade can be retried later if needed.
 		// This is needed when last upgrade failed and user has reset the version in spec.
@@ -123,7 +123,7 @@ func downgradeForBackend(master *v1alpha1.CDAPMaster) ([]reconciler.Object, erro
 	return []reconciler.Object{}, nil
 }
 
-func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, observed []reconciler.Object, isPatchRevision bool) ([]reconciler.Object, error) {
+func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, observed []reconciler.Object, patchRevision bool) ([]reconciler.Object, error) {
 	// Find either pre- or post- upgrade job
 	findJob := func(jobName string) *batchv1.Job {
 		var job *batchv1.Job = nil
@@ -157,17 +157,12 @@ func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, ob
 		return jobObj
 	}
 
-	SkipPreUpgradeFlag := !(master.Spec.Config[confSkipPreUpgradeFlag] == "false")
+	skipPreUpgrade := !(master.Spec.Config[confSkipPreUpgrade] == "false")
 
-	// Skip pre-upgrade and post-upgrade jobs for patch revision
-	if isPatchRevision && SkipPreUpgradeFlag {
+	// Skip pre-upgrade and post-upgrade jobs for patch revisions
+	if patchRevision && skipPreUpgrade {
 		log.Printf("Version update: patch revision detected, skipping pre-upgrade and post-upgrade jobs.")
-		setImageToUse(master)
-		setCondition(master, updateStatus.VersionUpdated)
-		setCondition(master, updateStatus.UpgradeSucceeded)
-		clearCondition(master, updateStatus.Inprogress)
-		log.Printf("Version update: patch revision completed.")
-		return []reconciler.Object{}, nil
+		skipPreUpgrade := true
 	}
 
 	// First, run pre-upgrade job
@@ -176,7 +171,7 @@ func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, ob
 	// try as many as imageVersionUpgradeJobMaxRetryCount times before giving up. If we ever
 	// needed to set an overall deadline for the pre-upgrade job, the logic below needs to check
 	// deadline exceeded condition on job's status
-	if !isConditionTrue(master, updateStatus.PreUpgradeSucceeded) {
+	if !isConditionTrue(master, updateStatus.PreUpgradeSucceeded) && !skipPreUpgrade {
 		log.Printf("Version update: pre-upgrade job not completed")
 		preJobName := getPreUpgradeJobName(master.Status.UpgradeStartTimeMillis)
 		preJobSpec := buildPreUpgradeJobSpec(getPreUpgradeJobName(master.Status.UpgradeStartTimeMillis), master, labels)
@@ -219,7 +214,7 @@ func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, ob
 	// try as many as imageVersionUpgradeJobMaxRetryCount times before giving up. If we ever
 	// needed to set an overall deadline for the post-upgrade job, the logic below needs to check
 	// deadline exceeded condition on job's status
-	if !isConditionTrue(master, updateStatus.PostUpgradeSucceeded) {
+	if !isConditionTrue(master, updateStatus.PostUpgradeSucceeded) && !skipPreUpgrade {
 		log.Printf("Version update: post-upgrade job not completed")
 		postJobName := getPostUpgradeJobName(master.Status.UpgradeStartTimeMillis)
 		postJobSpec := buildPostUpgradeJobSpec(getPostUpgradeJobName(master.Status.UpgradeStartTimeMillis), master, labels)
@@ -422,8 +417,7 @@ func parseImageString(imageString string) (*Version, error) {
 }
 
 // compare two parsed versions
-// -2: left < right, patch revision
-// -1: left < right
+// -n: left < right, nth component differs (1-indexed)
 // 0: left = right
 // 1: left > right
 func compareVersion(l, r *Version) int {
@@ -436,44 +430,32 @@ func compareVersion(l, r *Version) int {
 	}
 
 	lenL, lenR := len(l.components), len(r.components)
-	// Check if it only a patch revision
-	if lenL == lenR && lenL > 0 && l.components[lenL-1] < r.components[lenL-1] {
-		allEqual := true
-		for i := 0; i < lenL-1; i++ {
-			if l.components[i] != r.components[i] {
-				allEqual = false
-				break
-			}
-		}
-		if allEqual {
-			return -2
+	minLen := lenL
+	if lenR < lenL {
+		minLen = lenR
+	}
+
+	for i := 0; i < minLen; i++ {
+		if l.components[i] > r.components[i] {
+			return 1
+		} else if l.components[i] < r.components[i] {
+			return -(i + 1) // Return negative index (1-based)
 		}
 	}
 
-	i := 0
-	j := 0
-	for i < lenL && j < lenR {
-		if l.components[i] > r.components[j] {
-			return 1
-		} else if l.components[i] < r.components[j] {
-			return -1
-		}
-		i++
-		j++
-	}
-	for i < lenL {
+	// If one version has extra components that are non-zero, it's greater
+	for i := minLen; i < lenL; i++ {
 		if l.components[i] > 0 {
 			return 1
 		}
-		i++
 	}
-	for j < lenR {
-		if r.components[j] > 0 {
-			return 1
+	for i := minLen; i < lenR; i++ {
+		if r.components[i] > 0 {
+			return -(i + 1) // Return negative index (1-based)
 		}
-		j++
 	}
-	return 0
+
+	return 0 // Versions are equal
 }
 
 //////////////////////////////////

--- a/controllers/version_update.go
+++ b/controllers/version_update.go
@@ -157,18 +157,18 @@ func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, ob
 		return jobObj
 	}
 
-  SkipPreUpgradeFlag := !(master.Spec.Config[confSkipPreUpgradeFlag] == "false")
+	SkipPreUpgradeFlag := !(master.Spec.Config[confSkipPreUpgradeFlag] == "false")
 
 	// Skip pre-upgrade and post-upgrade jobs for patch revision
-  if isPatchRevision && SkipPreUpgradeFlag {
-    log.Printf("Version update: patch revision detected, skipping pre-upgrade and post-upgrade jobs.")
-    setImageToUse(master)
-    setCondition(master, updateStatus.VersionUpdated)
-    setCondition(master, updateStatus.UpgradeSucceeded)
-    clearCondition(master, updateStatus.Inprogress)
-    log.Printf("Version update: patch revision completed.")
-    return []reconciler.Object{}, nil
-  }
+	if isPatchRevision && SkipPreUpgradeFlag {
+		log.Printf("Version update: patch revision detected, skipping pre-upgrade and post-upgrade jobs.")
+		setImageToUse(master)
+		setCondition(master, updateStatus.VersionUpdated)
+		setCondition(master, updateStatus.UpgradeSucceeded)
+		clearCondition(master, updateStatus.Inprogress)
+		log.Printf("Version update: patch revision completed.")
+		return []reconciler.Object{}, nil
+	}
 
 	// First, run pre-upgrade job
 	//
@@ -435,20 +435,20 @@ func compareVersion(l, r *Version) int {
 		return -1
 	}
 
-  lenL, lenR := len(l.components), len(r.components)
-  // Check if it only a patch revision
-  if lenL == lenR && lenL > 0 && l.components[lenL-1] < r.components[lenL-1] {
-    allEqual := true
-    for i := 0; i < lenL-1; i++ {
-      if l.components[i] != r.components[i] {
-        allEqual = false
-        break
-      }
-    }
-    if allEqual {
-      return -2
-    }
-  }
+	lenL, lenR := len(l.components), len(r.components)
+	// Check if it only a patch revision
+	if lenL == lenR && lenL > 0 && l.components[lenL-1] < r.components[lenL-1] {
+		allEqual := true
+		for i := 0; i < lenL-1; i++ {
+			if l.components[i] != r.components[i] {
+				allEqual = false
+				break
+			}
+		}
+		if allEqual {
+			return -2
+		}
+	}
 
 	i := 0
 	j := 0
@@ -536,12 +536,12 @@ func getCurrentTimeMs() int64 {
 
 // The returned name is just the suffix of actual k8s object name, as we prepend it with const string + CR name
 func getPreUpgradeJobName(startTimeMs int64) string {
-	return fmt.Sprintf("pre-upgrade-job-%d", startTimeMs / 1000)
+	return fmt.Sprintf("pre-upgrade-job-%d", startTimeMs/1000)
 }
 
 // The returned name is just the suffix of actual k8s object name, as we prepend it with const string + CR name
 func getPostUpgradeJobName(startTimeMs int64) string {
-	return fmt.Sprintf("post-upgrade-job-%d", startTimeMs / 1000)
+	return fmt.Sprintf("post-upgrade-job-%d", startTimeMs/1000)
 }
 
 // Return pre-upgrade job spec

--- a/controllers/version_update.go
+++ b/controllers/version_update.go
@@ -157,12 +157,10 @@ func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, ob
 		return jobObj
 	}
 
-	skipPreUpgrade := !(master.Spec.Config[confSkipPreUpgrade] == "false")
-
 	// Skip pre-upgrade and post-upgrade jobs for patch revisions
-	if patchRevision && skipPreUpgrade {
+	skipPreUpgrade := patchRevision && !(master.Spec.Config[confSkipPreUpgrade] == "false")
+	if skipPreUpgrade {
 		log.Printf("Version update: patch revision detected, skipping pre-upgrade and post-upgrade jobs.")
-		skipPreUpgrade := true
 	}
 
 	// First, run pre-upgrade job

--- a/controllers/version_update.go
+++ b/controllers/version_update.go
@@ -61,10 +61,7 @@ func handleVersionUpdate(master *v1alpha1.CDAPMaster, labels map[string]string, 
 		return []reconciler.Object{}, nil
 	}
 
-	switch versionComparison {
-	case -1, -2, -3, -4:
-		// Upgrade case
-
+	if versionComparison < 0 { // Upgrade case
 		// Don't retry upgrade if it failed.
 		if isConditionTrue(master, updateStatus.UpgradeFailed) {
 			return []reconciler.Object{}, nil
@@ -77,14 +74,11 @@ func handleVersionUpdate(master *v1alpha1.CDAPMaster, labels map[string]string, 
 		master.Status.UpgradeStartTimeMillis = getCurrentTimeMs()
 		log.Printf("Version update: start upgrading %s -> %s ", curVersion.rawString, newVersion.rawString)
 		return upgradeForBackend(master, labels, observed, patchRevision)
-	case 0:
+	} else if versionComparison == 0 { // No change
 		// Reset all condition so that failed upgraded/downgrade can be retried later if needed.
 		// This is needed when last upgrade failed and user has reset the version in spec.
 		updateStatus.clearAllConditions(master)
-		break
-	case 1:
-		// Downgrade
-
+	} else { // Downgrade
 		// At the moment, downgrade never fails, so no need to check if isConditionTrue(downgrade failed)
 		updateStatus.clearAllConditions(master)
 		setCondition(master, updateStatus.Inprogress)
@@ -124,6 +118,16 @@ func downgradeForBackend(master *v1alpha1.CDAPMaster) ([]reconciler.Object, erro
 }
 
 func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, observed []reconciler.Object, patchRevision bool) ([]reconciler.Object, error) {
+	// Skip pre-upgrade and post-upgrade jobs for patch revisions
+	skipPreUpgrade := patchRevision && !(master.Spec.Config[confSkipPreUpgrade] == "false")
+	if skipPreUpgrade {
+		log.Printf("Version update: patch revision detected, skipping pre-upgrade and post-upgrade jobs.")
+		// Mark pre and post upgrade jobs as succeeded so they don't get triggered when reconciling
+		// versionComparison will become 0 after reconciliation -> patchRevision will become false
+		setCondition(master, updateStatus.PreUpgradeSucceeded)
+		setCondition(master, updateStatus.PostUpgradeSucceeded)
+	}
+
 	// Find either pre- or post- upgrade job
 	findJob := func(jobName string) *batchv1.Job {
 		var job *batchv1.Job = nil
@@ -155,16 +159,6 @@ func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, ob
 			},
 		}
 		return jobObj
-	}
-
-	// Skip pre-upgrade and post-upgrade jobs for patch revisions
-	skipPreUpgrade := patchRevision && !(master.Spec.Config[confSkipPreUpgrade] == "false")
-	if skipPreUpgrade {
-		log.Printf("Version update: patch revision detected, skipping pre-upgrade and post-upgrade jobs.")
-		// Mark pre and post upgrade jobs as succeeded so they don't get triggered when reconciling
-		// patchRevision will become false after reconciliation
-		setCondition(master, updateStatus.PreUpgradeSucceeded)
-		setCondition(master, updateStatus.PostUpgradeSucceeded)
 	}
 
 	// First, run pre-upgrade job
@@ -419,9 +413,9 @@ func parseImageString(imageString string) (*Version, error) {
 }
 
 // compare two parsed versions
-// -n: left < right, nth component differs (1-indexed)
+// n: left > right, nth component differs (1-indexed)
 // 0: left = right
-// 1: left > right
+// -n: left < right, nth component differs (1-indexed)
 func compareVersion(l, r *Version) int {
 	if l.latest && r.latest {
 		return 0
@@ -432,28 +426,24 @@ func compareVersion(l, r *Version) int {
 	}
 
 	lenL, lenR := len(l.components), len(r.components)
-	minLen := lenL
-	if lenR < lenL {
-		minLen = lenR
+	maxLen := lenL
+	if lenR > lenL {
+		maxLen = lenR
 	}
 
-	for i := 0; i < minLen; i++ {
-		if l.components[i] > r.components[i] {
-			return 1
-		} else if l.components[i] < r.components[i] {
-			return -(i + 1) // Return negative index (1-based)
+	for i := 0; i < maxLen; i++ {
+		valL, valR := 0, 0
+		if i < lenL {
+			valL = l.components[i]
 		}
-	}
+		if i < lenR {
+			valR = r.components[i]
+		}
 
-	// If one version has extra components that are non-zero, it's greater
-	for i := minLen; i < lenL; i++ {
-		if l.components[i] > 0 {
-			return 1
-		}
-	}
-	for i := minLen; i < lenR; i++ {
-		if r.components[i] > 0 {
-			return -(i + 1) // Return negative index (1-based)
+		if valL > valR {
+			return i + 1 // Return positive index (1-based) for left > right
+		} else if valL < valR {
+			return -(i + 1) // Return negative index (1-based) for left < right
 		}
 	}
 

--- a/controllers/version_update.go
+++ b/controllers/version_update.go
@@ -32,6 +32,17 @@ func init() {
 /////////////////////////////////////////////////////////////
 
 func handleVersionUpdate(master *v1alpha1.CDAPMaster, labels map[string]string, observed []reconciler.Object) ([]reconciler.Object, error) {
+	curVersion, err := getCurrentImageVersion(master)
+	if err != nil {
+		return nil, err
+	}
+	newVersion, err := getNewImageVersion(master)
+	if err != nil {
+		return nil, err
+	}
+	versionComparison := compareVersion(curVersion, newVersion)
+	isPatchRevision := versionComparison == -2
+
 	// Let the current update complete if there is any
 	if isConditionTrue(master, updateStatus.Inprogress) {
 		log.Printf("Version update ingress. Continue... ")
@@ -45,21 +56,13 @@ func handleVersionUpdate(master *v1alpha1.CDAPMaster, labels map[string]string, 
 	}
 
 	// Update backend service image version
-	curVersion, err := getCurrentImageVersion(master)
-	if err != nil {
-		return nil, err
-	}
-	newVersion, err := getNewImageVersion(master)
-	if err != nil {
-		return nil, err
-	}
 	if len(curVersion.rawString) == 0 {
 		setImageToUse(master)
 		return []reconciler.Object{}, nil
 	}
 
-	switch compareVersion(curVersion, newVersion) {
-	case -1:
+	switch versionComparison {
+	case -2, -1:
 		// Upgrade case
 
 		// Don't retry upgrade if it failed.
@@ -73,7 +76,7 @@ func handleVersionUpdate(master *v1alpha1.CDAPMaster, labels map[string]string, 
 		setCondition(master, updateStatus.Inprogress)
 		master.Status.UpgradeStartTimeMillis = getCurrentTimeMs()
 		log.Printf("Version update: start upgrading %s -> %s ", curVersion.rawString, newVersion.rawString)
-		return upgradeForBackend(master, labels, observed)
+		return upgradeForBackend(master, labels, observed, isPatchRevision)
 	case 0:
 		// Reset all condition so that failed upgraded/downgrade can be retried later if needed.
 		// This is needed when last upgrade failed and user has reset the version in spec.
@@ -120,7 +123,7 @@ func downgradeForBackend(master *v1alpha1.CDAPMaster) ([]reconciler.Object, erro
 	return []reconciler.Object{}, nil
 }
 
-func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, observed []reconciler.Object) ([]reconciler.Object, error) {
+func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, observed []reconciler.Object, isPatchRevision bool) ([]reconciler.Object, error) {
 	// Find either pre- or post- upgrade job
 	findJob := func(jobName string) *batchv1.Job {
 		var job *batchv1.Job = nil
@@ -153,6 +156,17 @@ func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, ob
 		}
 		return jobObj
 	}
+
+	// Skip pre-upgrade and post-upgrade jobs for patch revision
+  if isPatchRevision {
+    log.Printf("Version update: patch revision detected, skipping pre-upgrade and post-upgrade jobs.")
+    setImageToUse(master)
+    setCondition(master, updateStatus.VersionUpdated)
+    setCondition(master, updateStatus.UpgradeSucceeded)
+    clearCondition(master, updateStatus.Inprogress)
+    log.Printf("Version update: patch revision completed.")
+    return []reconciler.Object{}, nil
+  }
 
 	// First, run pre-upgrade job
 	//
@@ -406,6 +420,7 @@ func parseImageString(imageString string) (*Version, error) {
 }
 
 // compare two parsed versions
+// -2: left < right, patch revision
 // -1: left < right
 // 0: left = right
 // 1: left > right
@@ -418,9 +433,24 @@ func compareVersion(l, r *Version) int {
 		return -1
 	}
 
+  lenL, lenR := len(l.components), len(r.components)
+  // Check if it only a patch revision
+  if lenL == lenR && lenL > 0 && l.components[lenL-1] < r.components[lenL-1] {
+    allEqual := true
+    for i := 0; i < lenL-1; i++ {
+      if l.components[i] != r.components[i] {
+        allEqual = false
+        break
+      }
+    }
+    if allEqual {
+      return -2
+    }
+  }
+
 	i := 0
 	j := 0
-	for i < len(l.components) && j < len(r.components) {
+	for i < lenL && j < lenR {
 		if l.components[i] > r.components[j] {
 			return 1
 		} else if l.components[i] < r.components[j] {
@@ -429,13 +459,13 @@ func compareVersion(l, r *Version) int {
 		i++
 		j++
 	}
-	for i < len(l.components) {
+	for i < lenL {
 		if l.components[i] > 0 {
 			return 1
 		}
 		i++
 	}
-	for j < len(r.components) {
+	for j < lenR {
 		if r.components[j] > 0 {
 			return 1
 		}

--- a/controllers/version_update.go
+++ b/controllers/version_update.go
@@ -157,8 +157,10 @@ func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, ob
 		return jobObj
 	}
 
+  SkipPreUpgradeFlag := !(master.Spec.Config[confSkipPreUpgradeFlag] == "false")
+
 	// Skip pre-upgrade and post-upgrade jobs for patch revision
-  if isPatchRevision {
+  if isPatchRevision && SkipPreUpgradeFlag {
     log.Printf("Version update: patch revision detected, skipping pre-upgrade and post-upgrade jobs.")
     setImageToUse(master)
     setCondition(master, updateStatus.VersionUpdated)

--- a/controllers/version_update.go
+++ b/controllers/version_update.go
@@ -161,6 +161,10 @@ func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, ob
 	skipPreUpgrade := patchRevision && !(master.Spec.Config[confSkipPreUpgrade] == "false")
 	if skipPreUpgrade {
 		log.Printf("Version update: patch revision detected, skipping pre-upgrade and post-upgrade jobs.")
+		// Mark pre and post upgrade jobs as succeeded so they don't get triggered when reconciling
+		// patchRevision will become false after reconciliation
+		setCondition(master, updateStatus.PreUpgradeSucceeded)
+		setCondition(master, updateStatus.PostUpgradeSucceeded)
 	}
 
 	// First, run pre-upgrade job
@@ -169,7 +173,7 @@ func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, ob
 	// try as many as imageVersionUpgradeJobMaxRetryCount times before giving up. If we ever
 	// needed to set an overall deadline for the pre-upgrade job, the logic below needs to check
 	// deadline exceeded condition on job's status
-	if !isConditionTrue(master, updateStatus.PreUpgradeSucceeded) && !skipPreUpgrade {
+	if !isConditionTrue(master, updateStatus.PreUpgradeSucceeded) {
 		log.Printf("Version update: pre-upgrade job not completed")
 		preJobName := getPreUpgradeJobName(master.Status.UpgradeStartTimeMillis)
 		preJobSpec := buildPreUpgradeJobSpec(getPreUpgradeJobName(master.Status.UpgradeStartTimeMillis), master, labels)
@@ -212,7 +216,7 @@ func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, ob
 	// try as many as imageVersionUpgradeJobMaxRetryCount times before giving up. If we ever
 	// needed to set an overall deadline for the post-upgrade job, the logic below needs to check
 	// deadline exceeded condition on job's status
-	if !isConditionTrue(master, updateStatus.PostUpgradeSucceeded) && !skipPreUpgrade {
+	if !isConditionTrue(master, updateStatus.PostUpgradeSucceeded) {
 		log.Printf("Version update: post-upgrade job not completed")
 		postJobName := getPostUpgradeJobName(master.Status.UpgradeStartTimeMillis)
 		postJobSpec := buildPostUpgradeJobSpec(getPostUpgradeJobName(master.Status.UpgradeStartTimeMillis), master, labels)

--- a/controllers/version_update.go
+++ b/controllers/version_update.go
@@ -46,7 +46,7 @@ func handleVersionUpdate(master *v1alpha1.CDAPMaster, labels map[string]string, 
 	// Let the current update complete if there is any
 	if isConditionTrue(master, updateStatus.Inprogress) {
 		log.Printf("Version update ingress. Continue... ")
-		return upgradeForBackend(master, labels, observed)
+		return upgradeForBackend(master, labels, observed, isPatchRevision)
 	}
 
 	if objs, versionUpdated, err := updateForUserInterface(master); err != nil {

--- a/controllers/version_update.go
+++ b/controllers/version_update.go
@@ -61,7 +61,8 @@ func handleVersionUpdate(master *v1alpha1.CDAPMaster, labels map[string]string, 
 		return []reconciler.Object{}, nil
 	}
 
-	if versionComparison < 0 { // Upgrade case
+	if versionComparison < 0 {
+		// Upgrade case.
 		// Don't retry upgrade if it failed.
 		if isConditionTrue(master, updateStatus.UpgradeFailed) {
 			return []reconciler.Object{}, nil
@@ -74,11 +75,13 @@ func handleVersionUpdate(master *v1alpha1.CDAPMaster, labels map[string]string, 
 		master.Status.UpgradeStartTimeMillis = getCurrentTimeMs()
 		log.Printf("Version update: start upgrading %s -> %s ", curVersion.rawString, newVersion.rawString)
 		return upgradeForBackend(master, labels, observed, patchRevision)
-	} else if versionComparison == 0 { // No change
+	} else if versionComparison == 0 {
+		// No change.
 		// Reset all condition so that failed upgraded/downgrade can be retried later if needed.
 		// This is needed when last upgrade failed and user has reset the version in spec.
 		updateStatus.clearAllConditions(master)
-	} else { // Downgrade
+	} else {
+		// Downgrade case.
 		// At the moment, downgrade never fails, so no need to check if isConditionTrue(downgrade failed)
 		updateStatus.clearAllConditions(master)
 		setCondition(master, updateStatus.Inprogress)
@@ -120,13 +123,6 @@ func downgradeForBackend(master *v1alpha1.CDAPMaster) ([]reconciler.Object, erro
 func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, observed []reconciler.Object, patchRevision bool) ([]reconciler.Object, error) {
 	// Skip pre-upgrade and post-upgrade jobs for patch revisions
 	skipPreUpgrade := patchRevision && !(master.Spec.Config[confSkipPreUpgrade] == "false")
-	if skipPreUpgrade {
-		log.Printf("Version update: patch revision detected, skipping pre-upgrade and post-upgrade jobs.")
-		// Mark pre and post upgrade jobs as succeeded so they don't get triggered when reconciling
-		// versionComparison will become 0 after reconciliation -> patchRevision will become false
-		setCondition(master, updateStatus.PreUpgradeSucceeded)
-		setCondition(master, updateStatus.PostUpgradeSucceeded)
-	}
 
 	// Find either pre- or post- upgrade job
 	findJob := func(jobName string) *batchv1.Job {
@@ -161,46 +157,59 @@ func upgradeForBackend(master *v1alpha1.CDAPMaster, labels map[string]string, ob
 		return jobObj
 	}
 
-	// First, run pre-upgrade job
-	//
-	// Note that pre-upgrade job doesn't have an "activeDeadlineSeconds" set it on, so it will
-	// try as many as imageVersionUpgradeJobMaxRetryCount times before giving up. If we ever
-	// needed to set an overall deadline for the pre-upgrade job, the logic below needs to check
-	// deadline exceeded condition on job's status
-	if !isConditionTrue(master, updateStatus.PreUpgradeSucceeded) {
-		log.Printf("Version update: pre-upgrade job not completed")
-		preJobName := getPreUpgradeJobName(master.Status.UpgradeStartTimeMillis)
-		preJobSpec := buildPreUpgradeJobSpec(getPreUpgradeJobName(master.Status.UpgradeStartTimeMillis), master, labels)
-		job := findJob(preJobName)
-		if job == nil {
-			obj, err := createJob(preJobSpec)
-			if err != nil {
-				return nil, err
+	if !skipPreUpgrade {
+		// First, run pre-upgrade job
+		//
+		// Note that pre-upgrade job doesn't have an "activeDeadlineSeconds" set it on, so it will
+		// try as many as imageVersionUpgradeJobMaxRetryCount times before giving up. If we ever
+		// needed to set an overall deadline for the pre-upgrade job, the logic below needs to check
+		// deadline exceeded condition on job's status
+		if !isConditionTrue(master, updateStatus.PreUpgradeSucceeded) {
+			log.Printf("Version update: pre-upgrade job not completed")
+			preJobName := getPreUpgradeJobName(master.Status.UpgradeStartTimeMillis)
+			preJobSpec := buildPreUpgradeJobSpec(getPreUpgradeJobName(master.Status.UpgradeStartTimeMillis), master, labels)
+			job := findJob(preJobName)
+			if job == nil {
+				obj, err := createJob(preJobSpec)
+				if err != nil {
+					return nil, err
+				}
+				log.Printf("Version update: creating pre-upgrade job")
+				return []reconciler.Object{*obj}, nil
+			} else if job.Status.Succeeded > 0 {
+				setCondition(master, updateStatus.PreUpgradeSucceeded)
+				log.Printf("Version update: pre-upgrade job succeeded")
+				// Return empty to delete preUpgrade jobObj
+				return []reconciler.Object{}, nil
+			} else if job.Status.Failed > imageVersionUpgradeJobMaxRetryCount {
+				setCondition(master, updateStatus.PreUpgradeFailed)
+				setCondition(master, updateStatus.UpgradeFailed)
+				clearCondition(master, updateStatus.Inprogress)
+				log.Printf("Version update: pre-upgrade job failed, exceeded max retries.")
+				return []reconciler.Object{}, nil
+			} else {
+				log.Printf("Version update: pre-upgrade job inprogress.")
+				return []reconciler.Object{*buildObject(job)}, nil
 			}
-			log.Printf("Version update: creating pre-upgrade job")
-			return []reconciler.Object{*obj}, nil
-		} else if job.Status.Succeeded > 0 {
-			setCondition(master, updateStatus.PreUpgradeSucceeded)
-			log.Printf("Version update: pre-upgrade job succeeded")
-			// Return empty to delete preUpgrade jobObj
-			return []reconciler.Object{}, nil
-		} else if job.Status.Failed > imageVersionUpgradeJobMaxRetryCount {
-			setCondition(master, updateStatus.PreUpgradeFailed)
-			setCondition(master, updateStatus.UpgradeFailed)
-			clearCondition(master, updateStatus.Inprogress)
-			log.Printf("Version update: pre-upgrade job failed, exceeded max retries.")
-			return []reconciler.Object{}, nil
-		} else {
-			log.Printf("Version update: pre-upgrade job inprogress.")
-			return []reconciler.Object{*buildObject(job)}, nil
 		}
 	}
 
 	// Then, actually update the image version
 	if !isConditionTrue(master, updateStatus.VersionUpdated) {
+		// If it's a patch revision, skip the pre and post upgrade jobs. Mark the update as succeeded.
+		if skipPreUpgrade {
+			log.Printf("Version update: patch revision detected, skipping pre-upgrade and post-upgrade jobs.")
+		}
+
 		setImageToUse(master)
 		setCondition(master, updateStatus.VersionUpdated)
 		log.Printf("Version update: set new version.")
+
+		if skipPreUpgrade {
+			setCondition(master, updateStatus.UpgradeSucceeded)
+			clearCondition(master, updateStatus.Inprogress)
+			log.Printf("Version update: upgrade succeeded.")
+		}
 		return []reconciler.Object{}, nil
 	}
 

--- a/controllers/version_update_test.go
+++ b/controllers/version_update_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Controller Suite", func() {
 				Expect(compareVersion(high, low)).To(Equal(1))
 			}
 		})
-		It("Compare image versions in patch revision", func() {
+    It("Compare image versions in patch revision", func() {
       imagePairs := []Pair{
         Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.0.1"},
         Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.0.3"},

--- a/controllers/version_update_test.go
+++ b/controllers/version_update_test.go
@@ -55,21 +55,21 @@ var _ = Describe("Controller Suite", func() {
 				Expect(compareVersion(high, low)).To(Equal(1))
 			}
 		})
-    It("Compare image versions in patch revision", func() {
-      imagePairs := []Pair{
-        Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.0.1"},
-        Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.0.3"},
-        Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.0.9"},
-      }
-      for _, imagePair := range imagePairs {
-        low, err := parseImageString(imagePair.first.(string))
-        Expect(err).To(BeNil())
-        high, err := parseImageString(imagePair.second.(string))
-        Expect(err).To(BeNil())
-        Expect(compareVersion(low, high)).To(Equal(-2))
-        Expect(compareVersion(high, low)).To(Equal(1))
-      }
-    })
+		It("Compare image versions in patch revision", func() {
+			imagePairs := []Pair{
+				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.0.1"},
+				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.0.3"},
+				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.0.9"},
+			}
+			for _, imagePair := range imagePairs {
+				low, err := parseImageString(imagePair.first.(string))
+				Expect(err).To(BeNil())
+				high, err := parseImageString(imagePair.second.(string))
+				Expect(err).To(BeNil())
+				Expect(compareVersion(low, high)).To(Equal(-2))
+				Expect(compareVersion(high, low)).To(Equal(1))
+			}
+		})
 		It("Compare same image versions", func() {
 			imagePairs := []Pair{
 				Pair{"gcr.io/cdapio/cdap:latest", "gcr.io/cdapio/cdap:latest"},

--- a/controllers/version_update_test.go
+++ b/controllers/version_update_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Controller Suite", func() {
 				high, err := parseImageString(imagePair.second.(string))
 				Expect(err).To(BeNil())
 				Expect(compareVersion(low, high)).To(Equal(-2))
-				Expect(compareVersion(high, low)).To(Equal(1))
+				Expect(compareVersion(high, low)).To(Equal(2))
 			}
 		})
 		It("Compare image versions for difference in 3rd component", func() {
@@ -98,7 +98,7 @@ var _ = Describe("Controller Suite", func() {
 				high, err := parseImageString(imagePair.second.(string))
 				Expect(err).To(BeNil())
 				Expect(compareVersion(low, high)).To(Equal(-3))
-				Expect(compareVersion(high, low)).To(Equal(1))
+				Expect(compareVersion(high, low)).To(Equal(3))
 			}
 		})
 		It("Compare image versions for difference in 4th component", func() {
@@ -112,7 +112,7 @@ var _ = Describe("Controller Suite", func() {
 				high, err := parseImageString(imagePair.second.(string))
 				Expect(err).To(BeNil())
 				Expect(compareVersion(low, high)).To(Equal(-4))
-				Expect(compareVersion(high, low)).To(Equal(1))
+				Expect(compareVersion(high, low)).To(Equal(4))
 			}
 		})
 		It("Fail to parse invalid image string", func() {

--- a/controllers/version_update_test.go
+++ b/controllers/version_update_test.go
@@ -39,37 +39,6 @@ var _ = Describe("Controller Suite", func() {
 			Expect(version.latest).To(BeFalse())
 			Expect(version.components).To(Equal([]int{6, 0, 0, 0}))
 		})
-		It("Compare image versions", func() {
-			imagePairs := []Pair{
-				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:latest"},
-				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.1.0"},
-				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.1.0"},
-				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:7"},
-			}
-			for _, imagePair := range imagePairs {
-				low, err := parseImageString(imagePair.first.(string))
-				Expect(err).To(BeNil())
-				high, err := parseImageString(imagePair.second.(string))
-				Expect(err).To(BeNil())
-				Expect(compareVersion(low, high)).To(Equal(-1))
-				Expect(compareVersion(high, low)).To(Equal(1))
-			}
-		})
-		It("Compare image versions in patch revision", func() {
-			imagePairs := []Pair{
-				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.0.1"},
-				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.0.3"},
-				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.0.9"},
-			}
-			for _, imagePair := range imagePairs {
-				low, err := parseImageString(imagePair.first.(string))
-				Expect(err).To(BeNil())
-				high, err := parseImageString(imagePair.second.(string))
-				Expect(err).To(BeNil())
-				Expect(compareVersion(low, high)).To(Equal(-2))
-				Expect(compareVersion(high, low)).To(Equal(1))
-			}
-		})
 		It("Compare same image versions", func() {
 			imagePairs := []Pair{
 				Pair{"gcr.io/cdapio/cdap:latest", "gcr.io/cdapio/cdap:latest"},
@@ -83,6 +52,67 @@ var _ = Describe("Controller Suite", func() {
 				second, err := parseImageString(imagePair.second.(string))
 				Expect(err).To(BeNil())
 				Expect(compareVersion(first, second)).To(Equal(0))
+			}
+		})
+		It("Compare image versions for difference in 1st component", func() {
+			imagePairs := []Pair{
+				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:latest"},
+				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:7.0.0.0"},
+				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:7.1.0"},
+				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:7"},
+			}
+			for _, imagePair := range imagePairs {
+				low, err := parseImageString(imagePair.first.(string))
+				Expect(err).To(BeNil())
+				high, err := parseImageString(imagePair.second.(string))
+				Expect(err).To(BeNil())
+				Expect(compareVersion(low, high)).To(Equal(-1))
+				Expect(compareVersion(high, low)).To(Equal(1))
+			}
+		})
+		It("Compare image versions for difference in 2nd component", func() {
+			imagePairs := []Pair{
+				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.1.0.0"},
+				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.1.0"},
+				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.1.2"},
+				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.1"},
+			}
+			for _, imagePair := range imagePairs {
+				low, err := parseImageString(imagePair.first.(string))
+				Expect(err).To(BeNil())
+				high, err := parseImageString(imagePair.second.(string))
+				Expect(err).To(BeNil())
+				Expect(compareVersion(low, high)).To(Equal(-2))
+				Expect(compareVersion(high, low)).To(Equal(1))
+			}
+		})
+		It("Compare image versions for difference in 3rd component", func() {
+			imagePairs := []Pair{
+				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.1.0"},
+				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.1.2"},
+				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.1"},
+			}
+			for _, imagePair := range imagePairs {
+				low, err := parseImageString(imagePair.first.(string))
+				Expect(err).To(BeNil())
+				high, err := parseImageString(imagePair.second.(string))
+				Expect(err).To(BeNil())
+				Expect(compareVersion(low, high)).To(Equal(-3))
+				Expect(compareVersion(high, low)).To(Equal(1))
+			}
+		})
+		It("Compare image versions for difference in 4th component", func() {
+			imagePairs := []Pair{
+				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.0.1"},
+				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.0.2"},
+			}
+			for _, imagePair := range imagePairs {
+				low, err := parseImageString(imagePair.first.(string))
+				Expect(err).To(BeNil())
+				high, err := parseImageString(imagePair.second.(string))
+				Expect(err).To(BeNil())
+				Expect(compareVersion(low, high)).To(Equal(-4))
+				Expect(compareVersion(high, low)).To(Equal(1))
 			}
 		})
 		It("Fail to parse invalid image string", func() {

--- a/controllers/version_update_test.go
+++ b/controllers/version_update_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Controller Suite", func() {
 		It("Compare image versions", func() {
 			imagePairs := []Pair{
 				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:latest"},
-				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.0.1"},
+				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.1.0"},
 				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.1.0"},
 				Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:7"},
 			}
@@ -55,6 +55,21 @@ var _ = Describe("Controller Suite", func() {
 				Expect(compareVersion(high, low)).To(Equal(1))
 			}
 		})
+		It("Compare image versions in patch revision", func() {
+      imagePairs := []Pair{
+        Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.0.1"},
+        Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.0.3"},
+        Pair{"gcr.io/cdapio/cdap:6.0.0.0", "gcr.io/cdapio/cdap:6.0.0.9"},
+      }
+      for _, imagePair := range imagePairs {
+        low, err := parseImageString(imagePair.first.(string))
+        Expect(err).To(BeNil())
+        high, err := parseImageString(imagePair.second.(string))
+        Expect(err).To(BeNil())
+        Expect(compareVersion(low, high)).To(Equal(-2))
+        Expect(compareVersion(high, low)).To(Equal(1))
+      }
+    })
 		It("Compare same image versions", func() {
 			imagePairs := []Pair{
 				Pair{"gcr.io/cdapio/cdap:latest", "gcr.io/cdapio/cdap:latest"},


### PR DESCRIPTION
### Refactor upgrade logic to skip pre upgrade job in case of patch revisions

### Description

This change prevents pre upgrade job from stopping pipelines in case of patch revisions.

### Code change

- Modified `version_update.go, constants.go`

### Unit Tests

- Modified `version_update_test.go`
- Modified old tests to incorporate new return value from compareVersions function (-2 for patch revisions)
- Added a new test to check for patch revisions

### Tested
In case of patch revisions:
![Screenshot 2025-02-13 at 7 39 57 AM](https://github.com/user-attachments/assets/99ba4f4c-ec9a-440c-8002-db466beb8f77)

Patch revision with skip pre upgrade flag = false:
![Screenshot 2025-02-13 at 7 58 26 AM](https://github.com/user-attachments/assets/85f43706-f71b-42fa-aae0-739667d119fe)
![Screenshot 2025-02-13 at 8 53 20 AM](https://github.com/user-attachments/assets/2771fe78-f7bd-4d17-adb2-6481e5ad31df)

In other cases:
![Screenshot 2025-02-13 at 6 59 30 AM](https://github.com/user-attachments/assets/8835b5f6-b452-4018-b32f-a506b1206dba)