### PR TITLE
[CDAP-21153] Run StorageMain for appfabric deployment pod as initContainer

### DIFF
--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -409,6 +409,14 @@ func buildDeployment(master *v1alpha1.CDAPMaster, name string, services ServiceG
 		setAffinity(affinity).
 		setSecretMountDefaultMode(defaultMode)
 
+	// Run storage init for appfabic deployment pod.
+	// TODO(CDAP-21152): Either run storage init once during upgrade or enable
+	// for more deployments.
+	if name == "appfabric" {
+		spec = spec.withInitContainer(
+			newContainerSpec(master, "StorageInit", dataDir).setArgs(containerStorageMain))
+	}
+
 	// Add each service as a container
 	for _, s := range services {
 		ss, err := getCDAPServiceSpec(master, s)

--- a/controllers/spec.go
+++ b/controllers/spec.go
@@ -293,8 +293,9 @@ func (s *BaseSpec) setSecurityContext(securityContext *v1alpha1.SecurityContext)
 
 // For Deployment
 type DeploymentSpec struct {
-	Base       *BaseSpec        `json:"base,inline"`
-	Containers []*ContainerSpec `json:"containers,omitempty"`
+	Base           *BaseSpec        `json:"base,inline"`
+	InitContainers []*ContainerSpec `json:"initContainer,omitempty"`
+	Containers     []*ContainerSpec `json:"containers,omitempty"`
 }
 
 func newDeploymentSpec(master *v1alpha1.CDAPMaster, name string, labels map[string]string, cconf, hconf, sysappconf string) *DeploymentSpec {
@@ -330,6 +331,11 @@ func (s *DeploymentSpec) setPriorityClassName(name string) *DeploymentSpec {
 
 func (s *DeploymentSpec) addLabel(key, val string) *DeploymentSpec {
 	s.Base.Labels = mergeMaps(s.Base.Labels, map[string]string{key: val})
+	return s
+}
+
+func (s *DeploymentSpec) withInitContainer(containerSpec *ContainerSpec) *DeploymentSpec {
+	s.InitContainers = append(s.InitContainers, containerSpec)
 	return s
 }
 

--- a/controllers/testdata/appfabric.json
+++ b/controllers/testdata/appfabric.json
@@ -220,10 +220,6 @@
                 "mountPath": "/opt/cdap/master/system-app-config"
               },
               {
-                "mountPath": "/data",
-                "name": "cdap-test-appfabric-data"
-              },
-              {
                 "name": "cdap-security",
                 "readOnly": true,
                 "mountPath": "/etc/cdap/security"

--- a/templates/cdap-deployment.yaml
+++ b/templates/cdap-deployment.yaml
@@ -71,6 +71,41 @@ spec:
       priorityClassName: {{.Base.PriorityClassName}}
       {{end}}
       terminationGracePeriodSeconds: 120
+      {{range $c := .InitContainers}}
+      initContainers:
+        - name: {{$c.Name}}
+          image: {{$c.Image}}
+          workingDir: {{$c.WorkingDir}}
+          command:
+          {{range $v := $c.Command }}
+            - {{$v}}
+          {{end}}
+          args:
+          {{range $v := $c.Args }}
+            - {{$v}}
+          {{end}}
+          {{if $c.ImagePullPolicy}}
+          imagePullPolicy: {{$c.ImagePullPolicy}}
+          {{end}}
+          volumeMounts:
+            - name: podinfo
+              mountPath: /etc/podinfo
+              readOnly: true
+            - name: cdap-conf
+              mountPath: /etc/cdap/conf
+              readOnly: true
+            - name: hadoop-conf
+              mountPath: /etc/hadoop/conf
+              readOnly: true
+            - name: cdap-sysappconf
+              mountPath: /opt/cdap/master/system-app-config
+              readOnly: true
+            {{if $.Base.SecuritySecret}}
+            - name: cdap-security
+              mountPath: {{$.Base.SecuritySecretPath}}
+              readOnly: true
+            {{end}}
+      {{end}}
       {{range $c := .Containers}}
       containers:
         - name: {{$c.Name}}


### PR DESCRIPTION
[CDAP-21153] Run StorageMain for appfabric deployment pod as initContainer

### Issue
CDAP instance upgraded to 6.11 may have errors like `io.cdap.cdap.spi.data.InvalidFieldException: Field flow_control_status is not part of the schema of table run_records`.

### Root Cause

This happens when there is a race condition where Appfabric service starts up and loads schema (caches) from DB before other services initialize storage table with new fields. The loaded schema doesn't contain the new field and fails to write run record during execution of pipeline.

### Impact

If appfabric starts before the schema is updated after instance upgrade all the new tables and fields introduced will be missing in the schema cache, which can cause read / write operations to fail. This can happen for instance upgrade from any older version (eg. 6.9 where SCM was introduced with new tables and fields or 6.8 where new fields were added for LCM)

### Solution

Run storage init as part of appfabric pod, like other statefulsets. 

### Verification

- [x] Unit Tests
- [x] Docker image

[CDAP-21096]: https://cdap.atlassian.net/browse/CDAP-21096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CDAP-21153]: https://cdap.atlassian.net/browse/CDAP-21153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ