### PR TITLE
[CDAP-21155] Trim name of statefulset objects to 52 characters

### DIFF
--- a/templates/cdap-sts.yaml
+++ b/templates/cdap-sts.yaml
@@ -20,7 +20,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{.Base.Name}}
+  name: {{ printf "%.52s" .Base.Name }}
   namespace: {{.Base.Namespace}}
   {{if .Base.Labels}}
   labels:


### PR DESCRIPTION
### Issue

[CDAP-21155](https://cdap.atlassian.net/browse/CDAP-21155) Trim name of statefulset objects to 52 characters in cdap-operator

AppFabric Processor pod doesn’t get created if CDAP master resource name is longer than 28 characters.

Following errors are seen in the K8s cluster:

```
Warning  FailedCreate      5m51s (x20 over 44m)  statefulset-controller  create Pod cdap-aanayak-6110-final-image-rbac-appfabricprocessor-0 in StatefulSet cdap-aanayak-6110-final-image-rbac-appfabricprocessor failed error: Pod "cdap-<CDAP Master name>-appfabricprocessor-0" is invalid: metadata.labels: Invalid value: "cdap-<CDAP Master name>-appfabricprocessor-6dc54666b9": must be no more than 63 characters
```

### Root Cause

K8s generates a `metadata.label` for appfabric processor pod (managed by statefulsets) named `controller-revision-hash` which has value of format `cdap-<CDAP Master name>-appfabricprocessor-<10 character hash>` (eg. `cdap-abcdefghijabcdefghijabcdefghij-appfabricprocessor-64c9bb6f49`), which exceeds limit of 63 characters for label values.

This is a known limitation / issue in K8s which hasn’t been resolved yet: https://github.com/kubernetes/kubernetes/issues/79337 

### Solution

Trim the name of stateful set objects to 52 characters so that the value of generated label value is within limit of 63 characters.

### Verification

- [x] Docker image

Deployed CDAP master resource with name having 30 characters

```
$ kubectl get pods
NAME                                                              READY   STATUS    RESTARTS   AGE
...
...
cdap-abcdefghijabcdefghijabcdefghij-appfabric-75b4568b86-n9xm7    1/1     Running   0          118m
cdap-abcdefghijabcdefghijabcdefghij-appfabricprocess-0            2/2     Running   0          118m
cdap-abcdefghijabcdefghijabcdefghij-logs-0                        2/2     Running   0          118m
cdap-abcdefghijabcdefghijabcdefghij-metadata-58654cb8cc-b28qn     1/1     Running   0          118m
cdap-abcdefghijabcdefghijabcdefghij-metrics-0                     2/2     Running   0          118m
cdap-abcdefghijabcdefghijabcdefghij-previ-a04b97eb22-0            2/2     Running   0          116m
cdap-abcdefghijabcdefghijabcdefghij-previ-a04b97eb22-1            2/2     Running   0          116m
cdap-abcdefghijabcdefghijabcdefghij-previ-a04b97eb22-2            2/2     Running   0          116m
cdap-abcdefghijabcdefghijabcdefghij-previ-a04b97eb22-3            2/2     Running   0          116m
cdap-abcdefghijabcdefghijabcdefghij-previ-a04b97eb22-4            2/2     Running   0          116m
cdap-abcdefghijabcdefghijabcdefghij-preview-0                     2/2     Running   0          118m
cdap-abcdefghijabcdefghijabcdefghij-router-55bb4854dd-2zbcs       1/1     Running   0          118m
cdap-abcdefghijabcdefghijabcdefghij-runtime-0                     2/2     Running   0          118m
cdap-abcdefghijabcdefghijabcdefghij-runtime-agent-f9785567dhx47   1/1     Running   0          118m
cdap-abcdefghijabcdefghijabcdefghij-service-system-dataprexp2tl   1/1     Running   0          110m
cdap-abcdefghijabcdefghijabcdefghij-service-system-pipelinw47xw   1/1     Running   0          110m
cdap-abcdefghijabcdefghijabcdefghij-system-worker-2dfc2e0cs29vt   1/1     Running   0          115m
cdap-abcdefghijabcdefghijabcdefghij-task--4032943325-0            2/2     Running   0          115m
cdap-abcdefghijabcdefghijabcdefghij-task--4032943325-1            2/2     Running   0          115m
cdap-abcdefghijabcdefghijabcdefghij-task--4032943325-2            2/2     Running   0          115m
cdap-abcdefghijabcdefghijabcdefghij-userinterface-7bcbf7dbxhtp4   1/1     Running   0          118m
cdap-controller-0                                                 1/1     Running   0          118m
...
...
```

Deployed CDAP master resource with name having shorter name( < 28 characters)

```
$ kubectl get pods
NAME                                                              READY   STATUS    RESTARTS       AGE
cdap-cdap-short-name-appfabric-5b78f45cf8-qnnx4                   1/1     Running   0              116m
cdap-cdap-short-name-appfabricprocessor-0                         2/2     Running   0              116m
cdap-cdap-short-name-logs-0                                       2/2     Running   0              116m
cdap-cdap-short-name-metadata-6d75578655-46bk5                    1/1     Running   0              116m
cdap-cdap-short-name-metrics-0                                    2/2     Running   0              116m
cdap-cdap-short-name-preview-0                                    2/2     Running   0              116m
cdap-cdap-short-name-preview-runner-112f8-92883bd90f-0            2/2     Running   0              114m
cdap-cdap-short-name-preview-runner-112f8-92883bd90f-1            2/2     Running   0              114m
cdap-cdap-short-name-preview-runner-112f8-92883bd90f-2            2/2     Running   0              114m
cdap-cdap-short-name-preview-runner-112f8-92883bd90f-3            2/2     Running   0              114m
cdap-cdap-short-name-preview-runner-112f8-92883bd90f-4            2/2     Running   0              114m
cdap-cdap-short-name-router-65899676fd-nlhlp                      1/1     Running   0              116m
cdap-cdap-short-name-runtime-0                                    2/2     Running   0              116m
cdap-cdap-short-name-runtime-agent-5668b5b7c9-btdxr               1/1     Running   0              116m
cdap-cdap-short-name-service-system-dataprep-service-27592l2mf4   1/1     Running   0              108m
cdap-cdap-short-name-service-system-pipeline-studio-273d4072btz   1/1     Running   0              109m
cdap-cdap-short-name-system-worker-5e88a9a8-20e2-4146-8865xq28r   1/1     Running   0              114m
cdap-cdap-short-name-task-worker-3ef9e3c0-73bab53b4c-0            2/2     Running   0              114m
cdap-cdap-short-name-task-worker-3ef9e3c0-73bab53b4c-1            2/2     Running   0              114m
cdap-cdap-short-name-task-worker-3ef9e3c0-73bab53b4c-2            2/2     Running   1 (102s ago)   114m
cdap-cdap-short-name-userinterface-86977bcb57-qqmkg               1/1     Running   0              116m
cdap-controller-0                                                 1/1     Running   0              116m
```

[CDAP-21155]: https://cdap.atlassian.net/browse/CDAP-21155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ