### PR TITLE
[🍒][CDAP-21155] Trim name of statefulset objects to 52 characters

### DIFF
--- a/templates/cdap-sts.yaml
+++ b/templates/cdap-sts.yaml
@@ -20,7 +20,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{.Base.Name}}
+  name: {{ printf "%.52s" .Base.Name }}
   namespace: {{.Base.Namespace}}
   {{if .Base.Labels}}
   labels:


### PR DESCRIPTION
Cherry-pick of PR from `develop` to `release/3.0` branch: https://github.com/cdapio/cdap-operator/pull/146