### PR TITLE
[CDAP-21156] Add startupProbe support in router service

### DIFF
--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -331,7 +331,12 @@ func startupProbeSpec(serviceSpec *v1alpha1.CDAPServiceSpec, service string) (*c
 	}
 
 	serviceName := strings.ToLower(service)
-	endpoint := fmt.Sprintf("https://localhost:%d/v3/system/services/%s/status", port, serviceName)
+	var endpoint string
+	if serviceName == "router" {
+	  endpoint = fmt.Sprintf("http://localhost:%d/status", port)
+	} else {
+	  endpoint = fmt.Sprintf("https://localhost:%d/v3/system/services/%s/status", port, serviceName)
+	}
 
 	return &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{

--- a/controllers/testdata/cdap_master_cr.json
+++ b/controllers/testdata/cdap_master_cr.json
@@ -308,7 +308,13 @@
         "secret-key": "/my/secret/key"
       },
       "replicas": 2,
-      "servicePort": 11015
+      "servicePort": 11015,
+      "startupProbe": {
+        "port": 11015,
+        "periodSeconds": 2,
+        "timeoutSeconds": 1,
+        "failureThreshold": 60
+      }
     },
     "supportBundle": {
       "metadata": {

--- a/controllers/testdata/router.json
+++ b/controllers/testdata/router.json
@@ -116,6 +116,18 @@
               "readOnlyRootFilesystem": false,
               "allowPrivilegeEscalation": false
             },
+            "startupProbe": {
+              "periodSeconds": 2,
+              "failureThreshold": 60,
+              "exec": {
+                "command": [
+                  "sh",
+                  "-c",
+                  "curl -s -f -k http://localhost:11015/status"
+                ]
+              },
+              "timeoutSeconds": 1
+            },
             "terminationMessagePath": "/dev/termination-log",
             "terminationMessagePolicy": "File",
             "volumeMounts": [


### PR DESCRIPTION
[CDAP-21156](https://cdap.atlassian.net/browse/CDAP-21156) Add support for startupProbe in Router

CDAP router system service status is available at endpoint `http://localhost:11015/status`

### Verification

* [x] Unit Tests
* [x] Docker image

Following CDAP master config works:
```
router:
    ...
    ...
    startupProbe:
        failureThreshold: 60
        periodSeconds: 2
        port: 11015
        timeoutSeconds: 1
```

[CDAP-21156]: https://cdap.atlassian.net/browse/CDAP-21156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ