### PR TITLE
[CDAP-21183] Add support for startupProbe in userinterface container

### DIFF
--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -332,7 +332,7 @@ func startupProbeSpec(serviceSpec *v1alpha1.CDAPServiceSpec, service string) (*c
 
 	serviceName := strings.ToLower(service)
 	var endpoint string
-	if serviceName == "router" {
+	if serviceName == "router" || serviceName == "userinterface" {
 	  endpoint = fmt.Sprintf("http://localhost:%d/status", port)
 	} else {
 	  endpoint = fmt.Sprintf("https://localhost:%d/v3/system/services/%s/status", port, serviceName)

--- a/controllers/testdata/cdap_master_cr.json
+++ b/controllers/testdata/cdap_master_cr.json
@@ -375,7 +375,13 @@
           "memory": "100Mi"
         }
       },
-      "servicePort": 11011
+      "servicePort": 11011,
+      "startupProbe": {
+        "port": 11011,
+        "periodSeconds": 2,
+        "timeoutSeconds": 1,
+        "failureThreshold": 60
+      }
     },
     "userInterfaceImage": "gcr.io/cloud-data-fusion-images/cloud-data-fusion-ui:6.1.0.5"
   },

--- a/controllers/testdata/userinterface.json
+++ b/controllers/testdata/userinterface.json
@@ -102,6 +102,18 @@
               "readOnlyRootFilesystem": false,
               "allowPrivilegeEscalation": false
             },
+            "startupProbe": {
+              "periodSeconds": 2,
+              "failureThreshold": 60,
+              "exec": {
+                "command": [
+                  "sh",
+                  "-c",
+                  "curl -s -f -k http://localhost:11011/status"
+                ]
+              },
+              "timeoutSeconds": 1
+            },
             "terminationMessagePath": "/dev/termination-log",
             "terminationMessagePolicy": "File",
             "volumeMounts": [


### PR DESCRIPTION
[CDAP-21183](https://cdap.atlassian.net/browse/CDAP-21183) Add support for startupProbe in userinterface container

CDAP userinterface service status is available at endpoint `http://localhost:11015/status`

### Verification

* [x] Unit Tests
* [x] Docker image

Following CDAP master config works:
```
userinterface:
    ...
    ...
    startupProbe:
        failureThreshold: 60
        periodSeconds: 2
        port: 11015
        timeoutSeconds: 1
```

[CDAP-21183]: https://cdap.atlassian.net/browse/CDAP-21183