### PR TITLE
[CDAP-21258] Add FSGroupChangePolicy support to SecurityContext

### DIFF
--- a/api/v1alpha1/cdapmaster_types.go
+++ b/api/v1alpha1/cdapmaster_types.go
@@ -372,6 +372,10 @@ type SecurityContext struct {
 	// FSGroup mounts volumes as the specified group ID and gives the primary user access
 	// to that group. It is applied at the pod level.
 	FSGroup *int64 `json:"fsGroup,omitempty"`
+	// FSGroupChangePolicy defines behavior of changing ownership and permission of the volume
+	// before being mounted. Refer to official Kubernetes docs.
+	// +kubebuilder:validation:Enum=Always;OnRootMismatch
+	FSGroupChangePolicy *corev1.PodFSGroupChangePolicy `json:"fsGroupChangePolicy,omitempty"`
 	// AllowPrivilegeEscalation prevents the container process from running SUID binaries.
 	// It is applied at the container level.
 	AllowPrivilegeEscalation *bool `json:"allowPrivilegeEscalation,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -687,6 +687,11 @@ func (in *SecurityContext) DeepCopyInto(out *SecurityContext) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.FSGroupChangePolicy != nil {
+		in, out := &in.FSGroupChangePolicy, &out.FSGroupChangePolicy
+		*out = new(v1.PodFSGroupChangePolicy)
+		**out = **in
+	}
 	if in.AllowPrivilegeEscalation != nil {
 		in, out := &in.AllowPrivilegeEscalation, &out.AllowPrivilegeEscalation
 		*out = new(bool)

--- a/config/crd/bases/cdap.cdap.io_cdapmasters.yaml
+++ b/config/crd/bases/cdap.cdap.io_cdapmasters.yaml
@@ -4380,6 +4380,14 @@ spec:
                           to that group. It is applied at the pod level.
                         format: int64
                         type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          FSGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being mounted. Refer to official Kubernetes docs.
+                        enum:
+                        - Always
+                        - OnRootMismatch
+                        type: string
                       privileged:
                         description: |-
                           Privileged runs container in privileged mode. It is applied at the container level.
@@ -7214,6 +7222,14 @@ spec:
                           to that group. It is applied at the pod level.
                         format: int64
                         type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          FSGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being mounted. Refer to official Kubernetes docs.
+                        enum:
+                        - Always
+                        - OnRootMismatch
+                        type: string
                       privileged:
                         description: |-
                           Privileged runs container in privileged mode. It is applied at the container level.
@@ -10047,6 +10063,14 @@ spec:
                           to that group. It is applied at the pod level.
                         format: int64
                         type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          FSGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being mounted. Refer to official Kubernetes docs.
+                        enum:
+                        - Always
+                        - OnRootMismatch
+                        type: string
                       privileged:
                         description: |-
                           Privileged runs container in privileged mode. It is applied at the container level.
@@ -12884,6 +12908,14 @@ spec:
                           to that group. It is applied at the pod level.
                         format: int64
                         type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          FSGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being mounted. Refer to official Kubernetes docs.
+                        enum:
+                        - Always
+                        - OnRootMismatch
+                        type: string
                       privileged:
                         description: |-
                           Privileged runs container in privileged mode. It is applied at the container level.
@@ -15845,6 +15877,14 @@ spec:
                           to that group. It is applied at the pod level.
                         format: int64
                         type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          FSGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being mounted. Refer to official Kubernetes docs.
+                        enum:
+                        - Always
+                        - OnRootMismatch
+                        type: string
                       privileged:
                         description: |-
                           Privileged runs container in privileged mode. It is applied at the container level.
@@ -18677,6 +18717,14 @@ spec:
                           to that group. It is applied at the pod level.
                         format: int64
                         type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          FSGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being mounted. Refer to official Kubernetes docs.
+                        enum:
+                        - Always
+                        - OnRootMismatch
+                        type: string
                       privileged:
                         description: |-
                           Privileged runs container in privileged mode. It is applied at the container level.
@@ -21510,6 +21558,14 @@ spec:
                           to that group. It is applied at the pod level.
                         format: int64
                         type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          FSGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being mounted. Refer to official Kubernetes docs.
+                        enum:
+                        - Always
+                        - OnRootMismatch
+                        type: string
                       privileged:
                         description: |-
                           Privileged runs container in privileged mode. It is applied at the container level.
@@ -24331,6 +24387,14 @@ spec:
                           to that group. It is applied at the pod level.
                         format: int64
                         type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          FSGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being mounted. Refer to official Kubernetes docs.
+                        enum:
+                        - Always
+                        - OnRootMismatch
+                        type: string
                       privileged:
                         description: |-
                           Privileged runs container in privileged mode. It is applied at the container level.
@@ -28525,6 +28589,14 @@ spec:
                           to that group. It is applied at the pod level.
                         format: int64
                         type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          FSGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being mounted. Refer to official Kubernetes docs.
+                        enum:
+                        - Always
+                        - OnRootMismatch
+                        type: string
                       privileged:
                         description: |-
                           Privileged runs container in privileged mode. It is applied at the container level.
@@ -31369,6 +31441,14 @@ spec:
                           to that group. It is applied at the pod level.
                         format: int64
                         type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          FSGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being mounted. Refer to official Kubernetes docs.
+                        enum:
+                        - Always
+                        - OnRootMismatch
+                        type: string
                       privileged:
                         description: |-
                           Privileged runs container in privileged mode. It is applied at the container level.
@@ -34206,6 +34286,14 @@ spec:
                           to that group. It is applied at the pod level.
                         format: int64
                         type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          FSGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being mounted. Refer to official Kubernetes docs.
+                        enum:
+                        - Always
+                        - OnRootMismatch
+                        type: string
                       privileged:
                         description: |-
                           Privileged runs container in privileged mode. It is applied at the container level.
@@ -34305,6 +34393,14 @@ spec:
                       to that group. It is applied at the pod level.
                     format: int64
                     type: integer
+                  fsGroupChangePolicy:
+                    description: |-
+                      FSGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                      before being mounted. Refer to official Kubernetes docs.
+                    enum:
+                    - Always
+                    - OnRootMismatch
+                    type: string
                   privileged:
                     description: |-
                       Privileged runs container in privileged mode. It is applied at the container level.
@@ -37097,6 +37193,14 @@ spec:
                           to that group. It is applied at the pod level.
                         format: int64
                         type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          FSGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being mounted. Refer to official Kubernetes docs.
+                        enum:
+                        - Always
+                        - OnRootMismatch
+                        type: string
                       privileged:
                         description: |-
                           Privileged runs container in privileged mode. It is applied at the container level.
@@ -39933,6 +40037,14 @@ spec:
                           to that group. It is applied at the pod level.
                         format: int64
                         type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          FSGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being mounted. Refer to official Kubernetes docs.
+                        enum:
+                        - Always
+                        - OnRootMismatch
+                        type: string
                       privileged:
                         description: |-
                           Privileged runs container in privileged mode. It is applied at the container level.
@@ -42766,6 +42878,14 @@ spec:
                           to that group. It is applied at the pod level.
                         format: int64
                         type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          FSGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being mounted. Refer to official Kubernetes docs.
+                        enum:
+                        - Always
+                        - OnRootMismatch
+                        type: string
                       privileged:
                         description: |-
                           Privileged runs container in privileged mode. It is applied at the container level.
@@ -45610,6 +45730,14 @@ spec:
                           to that group. It is applied at the pod level.
                         format: int64
                         type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          FSGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being mounted. Refer to official Kubernetes docs.
+                        enum:
+                        - Always
+                        - OnRootMismatch
+                        type: string
                       privileged:
                         description: |-
                           Privileged runs container in privileged mode. It is applied at the container level.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,26 +1,13 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
 - apiGroups:
   - ""
   resources:
   - configmaps
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - services
   verbs:
   - create
@@ -34,6 +21,7 @@ rules:
   - apps
   resources:
   - deployments
+  - statefulsets
   verbs:
   - create
   - delete
@@ -50,18 +38,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - batch
   resources:

--- a/controllers/testdata/cdap_master_cr.json
+++ b/controllers/testdata/cdap_master_cr.json
@@ -206,6 +206,14 @@
           "memory": "100Mi"
         }
       },
+      "securityContext": {
+        "runAsUser": 1000,
+        "runAsGroup": 1000,
+        "fsGroup": 2000,
+        "fsGroupChangePolicy": "OnRootMismatch",
+        "runAsNonRoot": true,
+        "allowPrivilegeEscalation": false
+      },
       "storageSize": "100Gi"
     },
     "messaging": {

--- a/controllers/testdata/logs.json
+++ b/controllers/testdata/logs.json
@@ -192,6 +192,7 @@
         "schedulerName": "default-scheduler",
         "securityContext": {
           "fsGroup": 2000,
+          "fsGroupChangePolicy": "OnRootMismatch",
           "runAsGroup": 1000,
           "runAsUser": 1000,
           "runAsNonRoot": true

--- a/templates/cdap-deployment.yaml
+++ b/templates/cdap-deployment.yaml
@@ -54,6 +54,9 @@ spec:
         {{if .Base.SecurityContext.FSGroup}}
         fsGroup: {{.Base.SecurityContext.FSGroup}}
         {{end}}
+        {{if .Base.SecurityContext.FSGroupChangePolicy}}
+        fsGroupChangePolicy: {{.Base.SecurityContext.FSGroupChangePolicy}}
+        {{end}}
         # For boolean pointers, we always set the value and ensure there is a default set for nil values.
         runAsNonRoot: {{.Base.SecurityContext.RunAsNonRoot}}
       {{end}}

--- a/templates/cdap-sts.yaml
+++ b/templates/cdap-sts.yaml
@@ -55,6 +55,9 @@ spec:
         {{if .Base.SecurityContext.FSGroup}}
         fsGroup: {{.Base.SecurityContext.FSGroup}}
         {{end}}
+        {{if .Base.SecurityContext.FSGroupChangePolicy}}
+        fsGroupChangePolicy: {{.Base.SecurityContext.FSGroupChangePolicy}}
+        {{end}}
         # For boolean pointers, we always set the value and ensure there is a default set for nil values.
         runAsNonRoot: {{.Base.SecurityContext.RunAsNonRoot}}
       {{end}}


### PR DESCRIPTION
### Description
This PR adds support for `fsGroupChangePolicy` in the custom `SecurityContext` struct and renders it in the StatefulSet and Deployment pod templates. 

This allows configuring `fsGroupChangePolicy: "OnRootMismatch"` at the pod level. For pods mounting large persistent volumes (such as the CDAP `logs` service), this policy avoids recursive ownership/permission changes (`chown`) on pod startup if the volume's root directory permissions already match the desired `fsGroup`. This significantly reduces pod boot times.

### Testing Evidence
1. **Unit Tests**: Ran `make test` locally, and all 32 specs passed successfully.
2. **In-Cluster Verification**: 
   * Updated the CDAP Master CRD in a GKE test cluster : Deployed locally built cdap-operator image to a k8s cluster
   * **Case A: Valid Policy Specified**
     Configured `fsGroupChangePolicy: "OnRootMismatch"` under the `logs` service's `securityContext` in the `CDAPMaster` CR.
     * Verified the policy is correctly applied in the pod's `securityContext`:
       ```bash
       $ kubectl get pod <logs-pod-name> -o jsonpath='{.spec.securityContext}'
       {"fsGroupChangePolicy":"OnRootMismatch","runAsNonRoot":false}
       ```
     * The pod booted up instantly and is running successfully.
   * **Case B: Unspecified / Omitted (Backward Compatibility)**
     Omitted `fsGroupChangePolicy` from the `CDAPMaster` CR.
     * Verified the field is completely absent from the pod's `securityContext`, falling back to Kubernetes defaults:
       ```bash
       $ kubectl get pod <logs-pod-name> -o jsonpath='{.spec.securityContext}'
       {"runAsNonRoot":false}
       ```
   * **Case C: Invalid Policy (OpenAPI Validation)**
     Attempted to patch the `CDAPMaster` CR with an invalid value (`"InvalidValue"`).
     * Verified the Kubernetes API server rejected the request with the expected validation error:
       ```
       The CDAPMaster "..." is invalid: spec.logs.securityContext.fsGroupChangePolicy: Unsupported value: "InvalidValue": supported values: "Always", "OnRootMismatch"
       ```